### PR TITLE
feat: add private api and webhook controller scaffolding

### DIFF
--- a/backend/config/config.ts
+++ b/backend/config/config.ts
@@ -5,6 +5,9 @@ import { mnemonicValidate } from "@polkadot/util-crypto";
 const devUriRegEx = /^\/\/(Alice|Bob|Charlie|Dave|Eve|Ferdie)(\/[\/]?\d+)?$/;
 
 const ENV_SCHEMA = Joi.object({
+  API_PORT: Joi.number().min(1001).max(10_000).default(3000),
+  PRIVATE_PORT: Joi.number().min(1001).max(10_000),
+  PRIVATE_HOST: Joi.string().hostname(),
   ACCOUNT_SERVICE_URL: Joi.string().uri().required(),
   CONTENT_PUBLISHER_URL: Joi.string().uri().required(),
   CHAIN_ENVIRONMENT: Joi.string()
@@ -64,6 +67,19 @@ export class Config {
     }
 
     this.configValues = value;
+  }
+
+  public get port() {
+    return parseInt(this.configValues["API_PORT"]);
+  }
+
+  public get privatePort() {
+    const port = parseInt(this.configValues["PRIVATE_PORT"]);
+    return port || (this.port + 1);
+  }
+
+  public get privateHost() {
+    return this.configValues["PRIVATE_HOST"];
   }
 
   public get accountServiceUrl() {

--- a/backend/controllers/WebhookController.ts
+++ b/backend/controllers/WebhookController.ts
@@ -1,0 +1,17 @@
+import { Express, Request, Response } from "express";
+import { BaseController } from "./BaseController";
+import { HttpStatusCode } from "axios";
+
+export class  WebhookController extends BaseController {
+    constructor(app: Express) {
+        super(app, '/webhooks');
+    }
+
+    protected initializeRoutes(): void {
+        this.router.post('/account-service', this.authServiceWebhook.bind(this));
+    }
+
+    public authServiceWebhook(_req: Request, res: Response) {
+        return res.status(HttpStatusCode.Created).send();
+    }
+}

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -153,6 +153,7 @@ services:
         - social-app-backend:latest
     ports:
       - 3004:3000
+      - 3006:3001
     env_file:
       - path: .env.common.docker
         required: true

--- a/backend/environment/env.social-app-backend.docker.template
+++ b/backend/environment/env.social-app-backend.docker.template
@@ -1,6 +1,12 @@
 # Copy this file to "<project_root>/.env.social-app-backend.docker", and then tweak values for local development
 # Values in this file will override the same-named environnent variables in `.env.common.docker` for the social-app-backend
 
+# IP address for the private (backend-facing) API to bind to (default: use default interface)
+PRIVATE_IP=
+
+# Port number for the private (backend-facing) API to bind to (default: one higner than the public port)
+PRIVATE_PORT=
+
 # Base URL for the account-service
 ACCOUNT_SERVICE_URL=http://account-service-api:3000
 

--- a/backend/environment/env.social-app-backend.template
+++ b/backend/environment/env.social-app-backend.template
@@ -1,6 +1,12 @@
 # Copy this file to "<project_root>/.env.social-app-backend", and then tweak values for local development
 # Values in this file will override the same-named environnent variables in `.env.common` for the social-app-backend
 
+# IP address for the private (backend-facing) API to bind to (default: use default interface)
+PRIVATE_IP=
+
+# Port number for the private (backend-facing) API to bind to (default: one higner than the public port)
+PRIVATE_PORT=
+
 # Base URL for the account-service
 ACCOUNT_SERVICE_URL=http://0.0.0.0:3003
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -18,37 +18,41 @@ import { AssestsController } from "./controllers/AssetsController";
 import { BroadcastsController } from "./controllers/BroadcastsController";
 import { MulterError } from "multer";
 import logger from './logger';
+import { WebhookController } from "./controllers/WebhookController";
 
 // Support BigInt JSON
 (BigInt.prototype as any).toJSON = function () {
   return this.toString();
 };
 
-const DEFAULT_PORT = 3000;
-
 Config.init(process.env);
 
-const app = express();
-app.use(express.json());
+const publicApp = express();
+publicApp.use(express.json());
+publicApp.use(cors());
+publicApp.use(pinoHttp({ logger }));
 
-// cors
-app.use(cors());
-
-app.use(pinoHttp({ logger }));
+const privateApp = express();
+privateApp.use(express.json());
+privateApp.use(cors());
+privateApp.use(pinoHttp({ logger }));
 
 const _controllers = [
-  new AuthController(app),
-  new AssestsController(app),
-  new BroadcastsController(app),
-  new ContentController(app),
-  new GraphController(app),
-  new ProfilesController(app),
+  new AuthController(publicApp),
+  new AssestsController(publicApp),
+  new BroadcastsController(publicApp),
+  new ContentController(publicApp),
+  new GraphController(publicApp),
+  new ProfilesController(publicApp),
+
+  // private (backend) webhook controllers
+  new WebhookController(privateApp),
 ];
 
 // Swagger UI
-app.use("/docs", swaggerUi.serve, swaggerUi.setup(openapiJson));
+publicApp.use("/docs", swaggerUi.serve, swaggerUi.setup(openapiJson));
 
-app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+publicApp.use((err: any, req: Request, res: Response, next: NextFunction) => {
   if (res.headersSent) {
     return next(err);
   }
@@ -69,20 +73,22 @@ app.use((err: any, req: Request, res: Response, next: NextFunction) => {
   return res.status(500).json({ error: "An internal server error occurred." });
 });
 
-let port = parseInt(process.env.API_PORT || DEFAULT_PORT.toString());
-if (isNaN(port)) {
-  port = DEFAULT_PORT;
-}
+const { port, privatePort, privateHost } = Config.instance();
 if (process.env.NODE_ENV != "test") {
   // start server
-  app.listen(port, () => {
+  publicApp.listen(port, () => {
     getApi().catch((e) => {
-      console.error("Error connecting to Frequency Node!!", e.message);
+      logger.error("Error connecting to Frequency Node!!", e.message);
     });
-    console.info(
-      `api listening at http://localhost:${port}\nOpenAPI Docs at http://localhost:${port}/docs`,
-    );
+    logger.info('api listening at http://localhost:%d', port);
+    logger.info('OpenAPI Docs at http://localhost:%d/docs', port);
   });
+
+  if (privateHost) {
+    privateApp.listen(privatePort, privateHost, () => logger.info('private api listening at http://%s:%d', privateHost, privatePort));
+  } else {
+    privateApp.listen(privatePort, () => logger.info('private api listening at http://localhost:%d', privatePort))
+  }
 }
 
-export { app };
+export { publicApp as app, privateApp };


### PR DESCRIPTION
- add API_PORT to the Config class
- add PRIVATE_IP env var to support binding to a different interface for internal webhooks
- add PRIVATE_PORT env var to support specifying the port for the private api/webhooks API
- add basic/sample WebhooksController bound to the new private API app instance

# Purpose
The goal of this PR is to establish basic scaffolding for the "internal" API of the Gateway; that is, the API that supports webhooks being called from other backend services. We want the ability to have this API accessible on a different network address than the public-facing API, in order to support various network/security deployment configurations.

Related to #25, #33 