### PR TITLE
feat: allow env override of backend URL

### DIFF
--- a/frontend/src/chrome/UserAvatar.tsx
+++ b/frontend/src/chrome/UserAvatar.tsx
@@ -21,7 +21,7 @@ const UserAvatar = ({ user, avatarSize }: UserAvatarProps): ReactElement => {
   const iconURL = user
     ? user.profile?.icon ||
       React.useMemo(
-        () => `data:image/svg+xml;utf8,${encodeURIComponent(minidenticon(user.msaId.toString()))}`,
+        () => `data:image/svg+xml;utf8,${encodeURIComponent(minidenticon(user.msaId))}`,
         [user.msaId]
       )
     : '';

--- a/frontend/src/dsnpLink.ts
+++ b/frontend/src/dsnpLink.ts
@@ -201,12 +201,8 @@ export type AuthMethods = {
 export function configureAuth(params?: r.CreateContextParams<AuthMethods>["authProviders"]): AuthMethods {
     return { tokenAuth: params?.tokenAuth && new r.HttpBearerSecurityAuthentication(params.tokenAuth) };
 }
-// TODO: Was this file edited manually to add REACT_APP_BACKEND_URL?
-export function createContext<FetcherData>(
-  params?: r.CreateContextParams<AuthMethods, FetcherData>
-): r.Context<AuthMethods, FetcherData> {
-  return new r.Context<AuthMethods, FetcherData>({
-    serverConfiguration: new r.ServerConfiguration(process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000', {}),
+export function createContext<FetcherData>(params?: r.CreateContextParams<AuthMethods, FetcherData>): r.Context<AuthMethods, FetcherData> { return new r.Context<AuthMethods, FetcherData>({
+    serverConfiguration: new r.ServerConfiguration('http://localhost:3000', {}),
     authMethods: configureAuth(params?.authProviders),
     ...params
 }); }

--- a/frontend/src/login/LoginScreen.tsx
+++ b/frontend/src/login/LoginScreen.tsx
@@ -4,8 +4,9 @@ import * as dsnpLink from '../dsnpLink';
 import Login from './Login';
 import { UserAccount } from '../types';
 import styles from './LoginScreen.module.css';
+import { ServerConfiguration } from '@typoas/runtime';
 
-const dsnpLinkCtx = dsnpLink.createContext();
+const dsnpLinkCtx = process.env.REACT_APP_BACKEND_URL ? dsnpLink.createContext({ serverConfiguration: new ServerConfiguration(process.env.REACT_APP_BACKEND_URL, {})}) : dsnpLink.createContext();
 
 interface LoginScreenProps {
   onLogin: (account: UserAccount, providerInfo: dsnpLink.ProviderResponse) => void;

--- a/frontend/src/service/AuthService.ts
+++ b/frontend/src/service/AuthService.ts
@@ -1,3 +1,4 @@
+import { ServerConfiguration } from '@typoas/runtime';
 import * as dsnpLink from '../dsnpLink';
 
 let accessToken: string | null = null;
@@ -21,16 +22,22 @@ export const clearAccessToken = (token: string): void => {
  * @returns The context object.
  */
 export const getContext = () => {
-  if (accessToken === null) return dsnpLink.createContext();
+  const contextOptions: any = {}
+
+  if (process.env.REACT_APP_BACKEND_URL) {
+    contextOptions.serverConfiguration = new ServerConfiguration(process.env.REACT_APP_BACKEND_URL, {});
+  }
+
+  if (accessToken) {
+    contextOptions.authProviders = {
+      tokenAuth: {
+        getConfig: () => accessToken
+      }
+    }
+  }
 
   // TODO: Handle expiring tokens
 
   // TODO: Something might be broken in typoas. This is trying to fix it
-  return dsnpLink.createContext({
-    authProviders: {
-      tokenAuth: {
-        getConfig: () => accessToken,
-      } as any,
-    },
-  });
+  return dsnpLink.createContext(contextOptions);
 };


### PR DESCRIPTION
# Purpose
The goal of this PR is to allow the user to specify a URL for the social-gateway-backend in the environment that will override the value generated from the OpenAPI spec document.