### PR TITLE
fix: AssetsService return should use correct type

### DIFF
--- a/backend/services/AssetsService.ts
+++ b/backend/services/AssetsService.ts
@@ -1,9 +1,12 @@
 import FormData from 'form-data';
 import { ContentPublisherService } from './ContentPublisherService.js';
+import { Components } from '../types/openapi-content-publishing-service.js';
 
 type File = Express.Multer.File;
+type UploadAssetResponse = Components.Schemas.UploadResponseDto;
+
 export class AssetsService {
-  static async create(files: File[]): Promise<string[]> {
+  static async create(files: File[]): Promise<UploadAssetResponse> {
     const formData = files.reduce((acc, file) => {
       acc.append(file.fieldname, file.buffer, {
         filename: file.originalname,
@@ -15,7 +18,7 @@ export class AssetsService {
     try {
       const repository = await ContentPublisherService.getInstance();
       const response = await repository.uploadAsset(formData);
-      return response.assetIds;
+      return response;
     } catch (error) {
       console.error(error);
       throw error;


### PR DESCRIPTION
# Purpose
The goal of this PR is fix a problem with creating new posts where the `assetIds` are `null`.

## Solution

AssetsService, which handles the upload of assets, was returning a `string[]` which was being interpreted as `undefined`. The code was changed so that `AssetsService::create()` returns the `UploadAssetResponse` and the rest of the code can correctly interpret the `assetIds` and then the images will show in the posts correctly.

@saraswatpuneet 

## Steps to Verify
1. Create a new post with an attached image.
2. Verify that the post shows in the feed with a link to the image.
