### PR TITLE
fix: message content from chain properly resolved in both BE and FE

### DIFF
--- a/backend/ENVIRONMENT.md
+++ b/backend/ENVIRONMENT.md
@@ -2,17 +2,15 @@
 
 This application recognizes the following environment variables:
 
-| Name                           | Description                                                                          |          Range/Type           | Required? | Default |
-| ------------------------------ | ------------------------------------------------------------------------------------ | :---------------------------: | :-------: | :-----: |
-| `API_PORT`                     | HTTP port that the application listens on                                            |         1025 - 65535          |           |  3000   |
-| `FREQUENCY_HTTP_URL`           | Blockchain node address for the SiwF UI (must be resolvable from a browser)          |         http(s): URL          |     Y     |         |
-| `FREQUENCY_URL`                | Blockchain node address                                                              |    http(s): or ws(s): URL     |     Y     |         |
-| `PROVIDER_ACCOUNT_SEED_PHRASE` | Seed phrase for provider MSA control key                                             |            string             |     Y     |         |
-| `PROVIDER_ID`                  | Provider MSA ID                                                                      |            integer            |     Y     |         |
-| `CHAIN_ENVIRONMENT`            | What type of chain we're connected to                                                | dev\|rococo\|testnet\|mainnet |     Y     |         |
-| `IPFS_BASIC_AUTH_SECRET`       | If using Infura, put auth token here, or leave blank for Kubo RPC                    |            string             |     N     |  blank  |
-| `IPFS_BASIC_AUTH_USER`         | If using Infura, put Project ID here, or leave blank for Kubo RPC                    |            string             |     N     |  blank  |
-| `IPFS_ENDPOINT`                | URL to IPFS endpoint                                                                 |              URL              |     Y     |         |
-| `IPFS_GATEWAY_URL`             | IPFS gateway URL. '[CID]' is a token that will be replaced with an actual content ID |         URL template          |     Y     |         |
-| `SIWF_DOMAIN`                  | Domain to be used in SIWF login payloads                                             |            string             |     Y     |         |
-| `SIWF_URL`                     | URL for the SIgn-in with Frequency UI                                                |              URL              |     Y     |         |
+| Name                           | Description                                                                                                                          |          Range/Type           | Required? | Default |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | :---------------------------: | :-------: | :-----: |
+| `API_PORT`                     | HTTP port that the application listens on                                                                                            |         1025 - 65535          |           |  3000   |
+| `FREQUENCY_HTTP_URL`           | Blockchain node address for the SiwF UI (must be resolvable from a browser)                                                          |         http(s): URL          |     Y     |         |
+| `FREQUENCY_URL`                | Blockchain node address                                                                                                              |    http(s): or ws(s): URL     |     Y     |         |
+| `PROVIDER_ACCOUNT_SEED_PHRASE` | Seed phrase for provider MSA control key                                                                                             |            string             |     Y     |         |
+| `PROVIDER_ID`                  | Provider MSA ID                                                                                                                      |            integer            |     Y     |         |
+| `CHAIN_ENVIRONMENT`            | What type of chain we're connected to                                                                                                | dev\|rococo\|testnet\|mainnet |     Y     |         |
+| `IPFS_GATEWAY_URL`             | IPFS gateway domain URL. If set, will replace the 'protocol://domain:port' portion of content URLs loaded from the chain             |         URL template          |           |         |
+| `IPFS_UA_GATEWAY_URL`          | IPFS gateway domain URL (user-agent resolvable). If set, will override IPFS_GATEWAY_URL in the auth response sent to the user-agent. |         URL template          |           |         |
+| `SIWF_DOMAIN`                  | Domain to be used in SIWF login payloads                                                                                             |            string             |     Y     |         |
+| `SIWF_URL`                     | URL for the SIgn-in with Frequency UI                                                                                                |              URL              |     Y     |         |

--- a/backend/config/config.ts
+++ b/backend/config/config.ts
@@ -17,16 +17,8 @@ const ENV_SCHEMA = Joi.object({
     .valid(...['dev', 'rococo', 'testnet', 'mainnet'])
     .required(),
   DEBUG: Joi.string(),
-  IPFS_ENDPOINT: Joi.string().uri().required(),
-  IPFS_BASIC_AUTH_USER: Joi.string(),
-  IPFS_BASIC_AUTH_SECRET: Joi.string(),
-  IPFS_GATEWAY_URL: Joi.string()
-    .pattern(/\[CID\]/)
-    .required()
-    .custom((value, helpers) => {
-      const ret = Joi.string().uri().validate(value.replace('[CID]', 'cid'));
-      return ret?.error ? helpers.error(ret.error.details[0].type) : value;
-    }),
+  IPFS_GATEWAY_URL: Joi.string().uri(),
+  IPFS_UA_GATEWAY_URL: Joi.string().uri(),
   FREQUENCY_URL: Joi.string().uri().required(),
   FREQUENCY_HTTP_URL: Joi.string().uri().required(),
   PROVIDER_ID: Joi.number()
@@ -108,24 +100,12 @@ export class Config {
     return this.configValues?.['DEBUG'] ?? false;
   }
 
-  public get ipfsEndpoint() {
-    return this.configValues['IPFS_ENDPOINT'];
-  }
-
-  public get ipfsBasicAuthUser() {
-    return this.configValues?.['IPFS_BASIC_AUTH_USER'];
-  }
-
-  public get ipfsBasicAuthSecret() {
-    return this.configValues?.['IPFS_BASIC_AUTH_SECRET'];
-  }
-
   public get ipfsGatewayUrl() {
     return this.configValues['IPFS_GATEWAY_URL'];
   }
 
-  public getIpfsContentUrl(cid: string) {
-    return this.ipfsGatewayUrl.replace('[CID]', cid);
+  public get ipfsUserAgentGatewayUrl() {
+    return this.configValues['IPFS_UA_GATEWAY_URL'] || this.ipfsGatewayUrl;
   }
 
   public get frequencyUrl() {

--- a/backend/controllers/AuthController.ts
+++ b/backend/controllers/AuthController.ts
@@ -38,7 +38,7 @@ export class AuthController extends BaseController {
       .send({
         siwfUrl: payload.siwfUrl,
         nodeUrl: payload.frequencyRpcUrl,
-        ipfsGateway: Config.instance().ipfsGatewayUrl,
+        ipfsGateway: Config.instance().ipfsUserAgentGatewayUrl,
         providerId: payload.providerId,
         schemas: [1, 2, 3, 4, 5, 6, 8],
         network: Config.instance().chainType,

--- a/backend/environment/env.social-app-backend.docker.template
+++ b/backend/environment/env.social-app-backend.docker.template
@@ -34,19 +34,11 @@ SIWF_URL=https://amplicalabs.github.io/siwf/ui
 # Domain for the Sign-in with Frequency login payload
 SIWF_DOMAIN=localhost
 
-# URL to IPFS endpoint
-# IPFS_ENDPOINT="https://ipfs.infura.io:5001"
-IPFS_ENDPOINT="http://kubo_ipfs:5001"
+# IPFS gateway domain URL. If set, will replace the 'protocol://domain:port' portion of content URLs loaded from the chain
+IPFS_GATEWAY_URL="http://kubo_ipfs:8080"
 
-# If using Infura, put Project ID here, or leave blank for Kubo RPC
-# IPFS_BASIC_AUTH_USER=
-
-# If using Infura, put auth token here, or leave blank for Kubo RPC
-# IPFS_BASIC_AUTH_SECRET=
-
-# IPFS gateway URL. '[CID]' is a token that will be replaced with an actual content ID
-# IPFS_GATEWAY_URL="https://ipfs.io/ipfs/[CID]"
-IPFS_GATEWAY_URL="http://kubo_ipfs:8080/ipfs/[CID]"
+# IPFS gateway domain URL (user-agent resolvable). If set, will override IPFS_GATEWAY_URL in the auth response sent to the user-agent.
+IPFS_UA_GATEWAY_URL="http://localhost:8080"
 
 # Enable debug mode for development
 DEBUG=true

--- a/backend/environment/env.social-app-backend.template
+++ b/backend/environment/env.social-app-backend.template
@@ -58,19 +58,11 @@ SIWF_URL=https://amplicalabs.github.io/siwf/ui
 # Domain for the Sign-in with Frequency login payload
 SIWF_DOMAIN=localhost
 
-# URL to IPFS endpoint
-# IPFS_ENDPOINT="https://ipfs.infura.io:5001"
-IPFS_ENDPOINT="http://0.0.0.0:5001"
+# IPFS gateway domain URL. If set, will replace the 'protocol://domain:port' portion of content URLs loaded from the chain
+IPFS_GATEWAY_URL="http://localhost:8080"
 
-# If using Infura, put Project ID here, or leave blank for Kubo RPC
-# IPFS_BASIC_AUTH_USER=
-
-# If using Infura, put auth token here, or leave blank for Kubo RPC
-# IPFS_BASIC_AUTH_SECRET=
-
-# IPFS gateway URL. '[CID]' is a token that will be replaced with an actual content ID
-# IPFS_GATEWAY_URL="https://ipfs.io/ipfs/[CID]"
-IPFS_GATEWAY_URL="http://0.0.0.0:8080/ipfs/[CID]"
+# IPFS gateway domain URL (user-agent resolvable). If set, will override IPFS_GATEWAY_URL in the auth response sent to the user-agent.
+# IPFS_UA_GATEWAY_URL=
 
 # Enable debug mode for development
 DEBUG=true

--- a/backend/services/feed.ts
+++ b/backend/services/feed.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import * as ContentRepository from '../repositories/ContentRepository';
 import { AnnouncementResponse, AnnouncementType, BroadcastAnnouncement } from '../types/content-announcement';
 import logger from '../logger.js';
+import { translateContentUrl } from '../utils/url-transation.js';
 
 export type Post = T.Components.Schemas.BroadcastExtended;
 interface CachedPosts {
@@ -35,7 +36,7 @@ async function getPostContent(msg: AnnouncementResponse): Promise<[number, Post]
   try {
     const announcement = msg.announcement as BroadcastAnnouncement;
     // TODO: Validate Hash
-    const postResp = await axios.get(announcement.url, {
+    const postResp = await axios.get(translateContentUrl(announcement.url), {
       responseType: 'text',
       timeout: 10000,
     });

--- a/backend/utils/url-transation.ts
+++ b/backend/utils/url-transation.ts
@@ -1,0 +1,11 @@
+import * as Config from '../config/config';
+
+export function translateContentUrl(url: string) {
+  const ipfsUrl = Config.instance().ipfsGatewayUrl;
+
+  if (!ipfsUrl || !url.includes('ipfs.io/')) {
+    return url;
+  }
+
+  return url.replace(/http[s]{0,1}:\/\/ipfs.io/, ipfsUrl);
+}


### PR DESCRIPTION
# Purpose
The goal of this PR is to allow both the SAT frontend & backend properly resolve message content retrieved from the chain by rewriting the embedded content URL as appropriate.

Closes #55 