### PR TITLE
[WIP] Add testnet startup script and docker-compose-testnet.yaml file

### DIFF
--- a/backend/docker-compose-testnet.yaml
+++ b/backend/docker-compose-testnet.yaml
@@ -1,0 +1,191 @@
+x-common-environment: &common-environment
+  FREQUENCY_URL: 'wss://0.rpc.testnet.amplica.io'
+  FREQUENCY_HTTP_URL: 'https://0.rpc.testnet.amplica.io'
+  REDIS_URL: 'redis://redis:6379'
+  PROVIDER_ID: ${PROVIDER_ID}
+  PROVIDER_ACCOUNT_SEED_PHRASE: ${PROVIDER_ACCOUNT_SEED_PHRASE}
+  WEBHOOK_BASE_URL: 'http://social-app-template-backend:3001/webhooks'
+  WEBHOOK_FAILURE_THRESHOLD: 3
+  WEBHOOK_RETRY_INTERVAL_SECONDS: 10
+  HEALTH_CHECK_MAX_RETRIES: 4
+  HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: 10
+  HEALTH_CHECK_SUCCESS_THRESHOLD: 10
+  CAPACITY_LIMIT: '{"type":"percentage", "value":80}'
+  SIWF_URL: 'https://amplicalabs.github.io/siwf/ui'
+  SIWF_DOMAIN: 'localhost'
+  IPFS_ENDPOINT: 'http://ipfs:5001'
+  IPFS_GATEWAY_URL: 'https://ipfs.io/ipfs/[CID]'
+  QUEUE_HIGH_WATER: 1000
+  CHAIN_ENVIRONMENT: dev
+  DEBUG: true
+
+x-content-publishing-env: &content-publishing-env
+  START_PROCESS: api
+  FILE_UPLOAD_MAX_SIZE_IN_BYTES: 2000000000
+  ASSET_EXPIRATION_INTERVAL_SECONDS: 300
+  BATCH_INTERVAL_SECONDS: 12
+  BATCH_MAX_COUNT: 1000
+  ASSET_UPLOAD_VERIFICATION_DELAY_SECONDS: 5
+
+x-content-watcher-env: &content-watcher-env
+  IPFS_BASIC_AUTH_SECRET:
+  STARTING_BLOCK: 759882
+  BLOCKCHAIN_SCAN_INTERVAL_MINUTES: 1
+  WEBHOOK_FAILURE_THRESHOLD: 4
+  PROVIDER_BASE_URL: 'http://social-app-template-backend:3001/webhooks/content-watcher/announcements'
+
+x-graph-service-env: &graph-service-env
+  DEBOUNCE_SECONDS: 10
+  GRAPH_ENVIRONMENT_TYPE: Mainnet
+  RECONNECTION_SERVICE_REQUIRED: false
+  PROVIDER_BASE_URL: 'http://social-app-template-backend:3001/webhooks/graph-service'
+
+x-account-service-env: &account-service-env
+  PROVIDER_BASE_URL: 'http://social-app-template-backend:3001/webhooks/account-service'
+
+x-social-app-template-backend: &social-app-template-backend
+  ACCOUNT_SERVICE_URL: 'http://account-service-api:3000'
+  CONTENT_PUBLISHER_URL: 'http://content-publishing-service-api:3000'
+  CONTENT_WATCHER_URL: 'http://content-watcher-service:3000'
+  GRAPH_SERVICE_URL: 'http://graph-service-api:3000'
+  IPFS_UA_GATEWAY_URL: 'http://localhost:8080'
+  NODE_ENV: development
+
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+    networks:
+      - social-app-backend
+    volumes:
+      - redis_data:/data/redis
+
+  ipfs:
+    image: ipfs/kubo:latest
+    ports:
+      - 4001:4001
+      - 5001:5001
+      - 8080:8080
+    networks:
+      - social-app-backend
+    volumes:
+      - ipfs_data:/data/ipfs
+
+  content-publishing-service-api:
+    image: amplicalabs/content-publishing-service:latest
+    platform: linux/amd64
+    environment:
+      <<: [*common-environment, *content-publishing-env]
+    depends_on:
+      - redis
+      - ipfs
+    networks:
+      - social-app-backend
+
+  content-publishing-service-worker:
+    image: amplicalabs/content-publishing-service:latest
+    platform: linux/amd64
+    environment:
+      <<: [*common-environment, *content-publishing-env]
+      START_PROCESS: worker
+    depends_on:
+      - redis
+      - ipfs
+    networks:
+      - social-app-backend
+
+  content-watcher-service:
+    image: amplicalabs/content-watcher-service:latest
+    platform: linux/amd64
+    environment:
+      <<: [*common-environment, *content-watcher-env]
+    depends_on:
+      - redis
+      - ipfs
+    networks:
+      - social-app-backend
+
+  graph-service-api:
+    image: amplicalabs/graph-service:latest
+    platform: linux/amd64
+    environment:
+      <<: [*common-environment, *graph-service-env]
+      START_PROCESS: api
+    depends_on:
+      - redis
+    networks:
+      - social-app-backend
+
+  graph-service-worker:
+    image: amplicalabs/graph-service:latest
+    platform: linux/amd64
+    environment:
+      <<: [*common-environment, *graph-service-env]
+      START_PROCESS: worker
+    depends_on:
+      - redis
+    networks:
+      - social-app-backend
+
+  account-service-api:
+    image: amplicalabs/account-service:latest
+    platform: linux/amd64
+    command: api
+    environment:
+      <<: [*common-environment, *account-service-env]
+    depends_on:
+      - redis
+    networks:
+      - social-app-backend
+
+  account-service-worker:
+    image: amplicalabs/account-service:latest
+    platform: linux/amd64
+    command: worker
+    environment:
+      <<: [*common-environment, *account-service-env]
+    depends_on:
+      - redis
+    networks:
+      - social-app-backend
+
+  social-app-template-backend:
+    pull_policy: never
+    image: social-app-backend
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+      tags:
+        - social-app-backend:latest
+    ports:
+      - 3001:3000
+      - 3002:3001
+
+    environment:
+      <<: [*common-environment, *social-app-template-backend]
+      IPFS_GATEWAY_URL: 'http://ipfs:8080'
+    volumes:
+      - .:/app
+      - node_cache:/app/node_modules
+    networks:
+      - social-app-backend
+    depends_on:
+      - ipfs
+      - content-publishing-service-api
+      - content-publishing-service-worker
+      - account-service-api
+      - account-service-worker
+      - graph-service-api
+      - graph-service-worker
+    profiles:
+      - full
+volumes:
+  ipfs_data:
+  chainstorage:
+    external: false
+  node_cache:
+  redis_data:
+
+networks:
+  social-app-backend:

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -80,7 +80,7 @@ ContentWatcherService.getInstance().then((service) => {
       .map((v) => v as AnnouncementType)
   );
 
-  service.resetScanner({ immediate: true, rewindOffset: 14_400 });
+  service.resetScanner({ immediate: true, rewindOffset: 600 });
 });
 
 // Swagger UI

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "generate-types-content-announcement": "npx @hey-api/openapi-ts -i openapi-specs/content-announcement.openapi.json -o types/content-announcement",
     "generate-types-content-watcher": "npx openapi-client-axios-typegen openapi-specs/content-watcher-service.json > types/openapi-content-watcher-service.d.ts",
     "generate-types-content-publisher": "npx openapi-client-axios-typegen openapi-specs/content-publishing-service.json > types/openapi-content-publishing-service.d.ts",
-    "generate-types": "npm run generate-types-account-service ; npm run generate-types-graph-service ; npm run generate-types-content-watcher ; npm run generate-types-content-publisher",
+    "generate-types": "npm run generate-types-account-service ; npm run generate-types-graph-service ; npm run generate-types-content-watcher ; npm run generate-types-content-publisher ; npm run generate-types-backend",
     "local:init": "node scripts/local-init.cjs",
     "env:init": "sh scripts/init-environment.sh"
   },

--- a/backend/scripts/start-on-testnet.sh
+++ b/backend/scripts/start-on-testnet.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Stop and remove containers, networks
+echo "Stopping and removing containers, networks..."
+docker compose -f docker-compose-testnet.yaml --profile full down
+
+# Remove specified volumes to remove all state and start fresh
+echo "Removing specified volumes..."
+docker volume rm backend_redis_data
+docker volume rm backend_chainstorage
+docker volume rm backend_ipfs_data
+docker volume rm backend_node_cache
+
+# Ask for Provider ID and Provider Seed Phrase
+read -p "Enter Provider ID: " PROVIDER_ID
+read -p "Enter Provider Seed Phrase: " PROVIDER_ACCOUNT_SEED_PHRASE
+
+# Export the variables
+export PROVIDER_ID
+export PROVIDER_ACCOUNT_SEED_PHRASE
+
+# Start all services in detached mode
+echo "Starting all services..."
+docker compose -f docker-compose-testnet.yaml --profile full up -d


### PR DESCRIPTION
# Purpose
The goal of this PR is add a script that starts up SAT connected to the paseo testnet.

Closes #94

## Solution

- `./scripts/start-on-testnet.sh` implemented to run the `docker compose` command
  The script asks for the `PROVIDER_ID` and `PROVIDER_ACCOUNT_SEED_PHRASE` and passes the values as environment variables to the docker compose file.
- `docker-compose-testnet.yaml` added with changes to connect to testnet and remove dependency on the frequency container.

## Steps to Verify
1. Execute `backend/scripts/start-on-testnet.sh`.
2. Verify that all containers start correctly by examining Docker Desktop logs.
3. Launch the frontend and test SAT functionality.

## Notes
1. Content-watcher is updated to have a 2-hour (600) block rewind. This allows SAT to sync up with the current end of the chain quickly. However, it means that any posts more than 2 hours old will not show up. [A separate issue is in the works to update content-watcher so that it can sync further back, and still monitor the end of the chain and new posts]
2. Users will have to look up or know the Provider Id and Seed Phrase before running the startup script.

