### PR TITLE
79 add followers section to profile

### DIFF
--- a/backend/controllers/GraphController.ts
+++ b/backend/controllers/GraphController.ts
@@ -44,33 +44,6 @@ export class GraphController extends BaseController {
     }
   }
 
-  /**
-   * Retrieves the list of users that follow a given user.
-   *
-   * @param req - The request object.
-   * @param res - The response object.
-   * @returns A Promise that resolves to the list of users that follow the given user.
-   */
-  public async getFollowers(req: Request, res: Response) {
-    const msaId = req.params?.msaId;
-
-    if (!msaId) {
-      return res.status(HttpStatusCode.NotFound).send();
-    }
-
-    try {
-      const followers = await GraphService.getInstance().then((service) => service.getPublicFollowers(msaId));
-      return res.status(HttpStatusCode.Ok).send(followers);
-    } catch (err) {
-      logger.error({ err }, 'Error getting user followers');
-      if (err instanceof HttpError) {
-        return res.status(err.code).send(err.message);
-      }
-
-      return res.status(HttpStatusCode.InternalServerError).send();
-    }
-  }
-
   public async postFollow(req: Request, res: Response) {
     const msaId = req.headers?.['msaId'];
 

--- a/backend/controllers/GraphController.ts
+++ b/backend/controllers/GraphController.ts
@@ -44,6 +44,33 @@ export class GraphController extends BaseController {
     }
   }
 
+  /**
+   * Retrieves the list of users that follow a given user.
+   *
+   * @param req - The request object.
+   * @param res - The response object.
+   * @returns A Promise that resolves to the list of users that follow the given user.
+   */
+  public async getFollowers(req: Request, res: Response) {
+    const msaId = req.params?.msaId;
+
+    if (!msaId) {
+      return res.status(HttpStatusCode.NotFound).send();
+    }
+
+    try {
+      const followers = await GraphService.getInstance().then((service) => service.getPublicFollowers(msaId));
+      return res.status(HttpStatusCode.Ok).send(followers);
+    } catch (err) {
+      logger.error({ err }, 'Error getting user followers');
+      if (err instanceof HttpError) {
+        return res.status(err.code).send(err.message);
+      }
+
+      return res.status(HttpStatusCode.InternalServerError).send();
+    }
+  }
+
   public async postFollow(req: Request, res: Response) {
     const msaId = req.headers?.['msaId'];
 

--- a/frontend/src/chrome/Profile.module.css
+++ b/frontend/src/chrome/Profile.module.css
@@ -12,10 +12,6 @@
   border-bottom: 2px solid;
 }
 
-.profile {
-  margin: 15px 0;
-}
-
 .metaInnerBlock {
   display: flex;
   align-items: center;

--- a/frontend/src/chrome/Profile.tsx
+++ b/frontend/src/chrome/Profile.tsx
@@ -5,8 +5,6 @@ import styles from './Profile.module.css';
 import UserAvatar from '../chrome/UserAvatar';
 import { FromTitle } from '../content/FromTitle';
 import GraphChangeButton from '../network/GraphChangeButton';
-import ConnectionsList from '../network/ConnectionsList';
-import { getUserProfile } from '../service/UserProfileService';
 import * as dsnpLink from '../dsnpLink';
 import { getContext } from '../service/AuthService';
 import Connections from '../network/Connections';
@@ -31,6 +29,7 @@ export const Profile = ({
   const [profileFollowingList, setProfileFollowingList] = useState<string[]>([]);
 
   const geProfileGraph = async () => {
+    console.log(profile.msaId);
     const following = await dsnpLink.userFollowing(getContext(), { msaId: profile.msaId });
     setProfileFollowingList(following);
   };
@@ -63,9 +62,9 @@ export const Profile = ({
           )}
           <Connections
             triggerGraphRefresh={getGraph}
-            account={profile}
+            loggedInAccount={loggedInAccount}
+            profile={profile}
             accountFollowingList={profileFollowingList || []}
-            graphRootUser={profile}
           />
         </Flex>
       )}

--- a/frontend/src/chrome/Profile.tsx
+++ b/frontend/src/chrome/Profile.tsx
@@ -9,6 +9,7 @@ import ConnectionsList from '../network/ConnectionsList';
 import { getUserProfile } from '../service/UserProfileService';
 import * as dsnpLink from '../dsnpLink';
 import { getContext } from '../service/AuthService';
+import Connections from '../network/Connections';
 
 interface ProfileProps {
   loggedInAccount: UserAccount;
@@ -27,15 +28,15 @@ export const Profile = ({
 }: ProfileProps): ReactElement => {
   const secondary = profile?.profile?.name || '';
 
-  const [loggedInAccountFollowing, setLoggedInAccountFollowing] = useState<string[]>([]);
+  const [profileFollowingList, setProfileFollowingList] = useState<string[]>([]);
 
-  const getLoggedInAccountGraph = async () => {
-    const following = await dsnpLink.userFollowing(getContext(), { msaId: loggedInAccount.msaId });
-    setLoggedInAccountFollowing(following);
+  const geProfileGraph = async () => {
+    const following = await dsnpLink.userFollowing(getContext(), { msaId: profile.msaId });
+    setProfileFollowingList(following);
   };
 
   useState(() => {
-    getLoggedInAccountGraph();
+    geProfileGraph();
   });
 
   return (
@@ -54,18 +55,16 @@ export const Profile = ({
             <GraphChangeButton
               key={accountFollowing.length}
               user={profile}
-              triggerGraphRefresh={getLoggedInAccountGraph}
+              triggerGraphRefresh={geProfileGraph}
               relationshipStatus={
-                loggedInAccountFollowing.includes(profile.msaId)
-                  ? RelationshipStatus.FOLLOWING
-                  : RelationshipStatus.NONE
+                profileFollowingList.includes(profile.msaId) ? RelationshipStatus.FOLLOWING : RelationshipStatus.NONE
               }
             />
           )}
-          <ConnectionsList
+          <Connections
             triggerGraphRefresh={getGraph}
             account={profile}
-            accountFollowing={accountFollowing || []}
+            accountFollowingList={profileFollowingList || []}
             graphRootUser={profile}
           />
         </>

--- a/frontend/src/chrome/Profile.tsx
+++ b/frontend/src/chrome/Profile.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { RelationshipStatus, User, UserAccount } from '../types';
-import { Card, Spin } from 'antd';
+import { Card, Flex, Spin } from 'antd';
 import styles from './Profile.module.css';
 import UserAvatar from '../chrome/UserAvatar';
 import { FromTitle } from '../content/FromTitle';
@@ -44,13 +44,13 @@ export const Profile = ({
       {isLoading ? (
         <Spin />
       ) : (
-        <>
+        <Flex gap={'large'} vertical>
           <Card.Meta
             className={styles.metaInnerBlock}
             avatar={<UserAvatar user={profile} avatarSize={'medium'} />}
             title={<FromTitle level={2} user={profile} />}
           />
-          <div className={styles.profile}>{secondary ? secondary : 'No Profile'}</div>
+          <div>{secondary ? secondary : 'No Profile'}</div>
           {loggedInAccount.msaId !== profile.msaId && (
             <GraphChangeButton
               key={accountFollowing.length}
@@ -67,7 +67,7 @@ export const Profile = ({
             accountFollowingList={profileFollowingList || []}
             graphRootUser={profile}
           />
-        </>
+        </Flex>
       )}
     </div>
   );

--- a/frontend/src/chrome/ProfilePage.tsx
+++ b/frontend/src/chrome/ProfilePage.tsx
@@ -24,15 +24,7 @@ const ProfilePage = ({ loggedInAccount, network, isPosting, refreshTrigger }: Pr
   };
 
   const [profile, setProfile] = useState<UserAccount>();
-  const [accountFollowing, setAccountFollowing] = useState<string[]>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-
-  const getGraph = async () => {
-    if (profile?.msaId) {
-      const following = await dsnpLink.userFollowing(getContext(), { msaId: profile.msaId });
-      setAccountFollowing(following);
-    }
-  };
 
   useEffect(() => {
     const msaId = getCurMsa();
@@ -41,7 +33,6 @@ const ProfilePage = ({ loggedInAccount, network, isPosting, refreshTrigger }: Pr
         setIsLoading(true);
         const curProfile = await getUserProfile(msaId);
         curProfile && setProfile(curProfile as UserAccount);
-        await getGraph();
       }
     };
 
@@ -53,13 +44,7 @@ const ProfilePage = ({ loggedInAccount, network, isPosting, refreshTrigger }: Pr
 
   return (
     <Spin tip="Loading" size="large" spinning={isLoading}>
-      <Profile
-        loggedInAccount={loggedInAccount}
-        profile={profile}
-        getGraph={getGraph}
-        isLoading={isLoading}
-        accountFollowing={accountFollowing ?? []}
-      />
+      <Profile loggedInAccount={loggedInAccount} profile={profile} isLoading={isLoading} />
       <Feed
         profile={profile}
         network={network}

--- a/frontend/src/content/NewPostModal.tsx
+++ b/frontend/src/content/NewPostModal.tsx
@@ -57,8 +57,6 @@ const NewPostModal = ({ onSuccess, onCancel, loggedInAccount }: NewPostProps): R
           assets: assetIds,
         }
       );
-
-      console.log('postBroadcastHandler', { response });
       success();
     } catch (e) {
       console.error(e);

--- a/frontend/src/content/Post.module.css
+++ b/frontend/src/content/Post.module.css
@@ -18,7 +18,7 @@
 }
 
 .caption {
-  margin: 16px 0;
+  margin: 16px 0 26px;
   word-wrap: break-word;
   overflow-wrap: break-word;
   hyphens: auto;

--- a/frontend/src/network/Connections.tsx
+++ b/frontend/src/network/Connections.tsx
@@ -5,13 +5,13 @@ import ConnectionsModal from './ConnectionsModal';
 import styles from './ConnectionsList.module.css';
 
 interface ConnectionsProps {
-  account: UserAccount;
   accountFollowingList: string[];
-  graphRootUser: User;
+  loggedInAccount: UserAccount;
+  profile: UserAccount;
   triggerGraphRefresh: () => void;
 }
 
-const Connections = ({ account, accountFollowingList, graphRootUser, triggerGraphRefresh }: ConnectionsProps) => {
+const Connections = ({ loggedInAccount, accountFollowingList, profile, triggerGraphRefresh }: ConnectionsProps) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [connectionsType, setConnectionsType] = useState<ConnectionsType>(ConnectionsType.FOLLOWERS);
 
@@ -47,11 +47,11 @@ const Connections = ({ account, accountFollowingList, graphRootUser, triggerGrap
         isModalOpen={isModalOpen}
         handleCancel={handleCancel}
         triggerGraphRefresh={triggerGraphRefresh}
-        account={account}
+        loggedInAccount={loggedInAccount}
         accountFollowingList={accountFollowingList}
         connectionsType={connectionsType}
         setConnectionsType={(type: ConnectionsType) => setConnectionsType(type)}
-        graphRootUser={graphRootUser}
+        profile={profile}
       />
     </>
   );

--- a/frontend/src/network/Connections.tsx
+++ b/frontend/src/network/Connections.tsx
@@ -1,0 +1,40 @@
+import { Button, Flex, Modal } from 'antd';
+import React, { useState } from 'react';
+
+const Connections = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const showModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleOk = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <Flex>
+        <div>
+          <span>31</span>
+          <span>Followers</span>
+        </div>
+        <div>
+          <span>31</span>
+          <span>Following</span>
+        </div>
+      </Flex>
+
+      <Button type="primary" onClick={showModal}>
+        Open Modal
+      </Button>
+      <Modal title="Basic Modal" open={isModalOpen} onOk={handleOk} onCancel={handleCancel}></Modal>
+    </>
+  );
+};
+
+export default Connections;

--- a/frontend/src/network/Connections.tsx
+++ b/frontend/src/network/Connections.tsx
@@ -1,38 +1,58 @@
-import { Button, Flex, Modal } from 'antd';
+import { Flex } from 'antd';
 import React, { useState } from 'react';
+import { ConnectionsType, User, UserAccount } from '../types';
+import ConnectionsModal from './ConnectionsModal';
+import styles from './ConnectionsList.module.css';
 
-const Connections = () => {
+interface ConnectionsProps {
+  account: UserAccount;
+  accountFollowingList: string[];
+  graphRootUser: User;
+  triggerGraphRefresh: () => void;
+}
+
+const Connections = ({ account, accountFollowingList, graphRootUser, triggerGraphRefresh }: ConnectionsProps) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [connectionsType, setConnectionsType] = useState<ConnectionsType>(ConnectionsType.FOLLOWERS);
 
-  const showModal = () => {
+  const showModal = (type: ConnectionsType) => {
     setIsModalOpen(true);
-  };
-
-  const handleOk = () => {
-    setIsModalOpen(false);
+    setConnectionsType(type);
   };
 
   const handleCancel = () => {
     setIsModalOpen(false);
   };
 
+  console.log('accountFollowing', accountFollowingList);
+
   return (
     <>
-      <Flex>
+      <Flex gap={'large'}>
         <div>
-          <span>31</span>
-          <span>Followers</span>
+          <span className={styles.ConnectionsCount}>{accountFollowingList.length}</span>
+          <span className={styles.ConnectionsOpenModal} onClick={() => showModal(ConnectionsType.FOLLOWING)}>
+            Following
+          </span>
         </div>
         <div>
-          <span>31</span>
-          <span>Following</span>
+          <span className={styles.ConnectionsCount}>?</span>
+          <span className={styles.ConnectionsOpenModal} onClick={() => showModal(ConnectionsType.FOLLOWERS)}>
+            Followers
+          </span>
         </div>
       </Flex>
 
-      <Button type="primary" onClick={showModal}>
-        Open Modal
-      </Button>
-      <Modal title="Basic Modal" open={isModalOpen} onOk={handleOk} onCancel={handleCancel}></Modal>
+      <ConnectionsModal
+        isModalOpen={isModalOpen}
+        handleCancel={handleCancel}
+        triggerGraphRefresh={triggerGraphRefresh}
+        account={account}
+        accountFollowingList={accountFollowingList}
+        connectionsType={connectionsType}
+        setConnectionsType={(type: ConnectionsType) => setConnectionsType(type)}
+        graphRootUser={graphRootUser}
+      />
     </>
   );
 };

--- a/frontend/src/network/Connections.tsx
+++ b/frontend/src/network/Connections.tsx
@@ -5,13 +5,20 @@ import ConnectionsModal from './ConnectionsModal';
 import styles from './ConnectionsList.module.css';
 
 interface ConnectionsProps {
-  accountFollowingList: string[];
+  loggedInAccountConnections: string[];
+  curProfileConnections: string[];
   loggedInAccount: UserAccount;
   profile: UserAccount;
   triggerGraphRefresh: () => void;
 }
 
-const Connections = ({ loggedInAccount, accountFollowingList, profile, triggerGraphRefresh }: ConnectionsProps) => {
+const Connections = ({
+  loggedInAccount,
+  loggedInAccountConnections,
+  profile,
+  curProfileConnections,
+  triggerGraphRefresh,
+}: ConnectionsProps) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [connectionsType, setConnectionsType] = useState<ConnectionsType>(ConnectionsType.FOLLOWERS);
 
@@ -24,13 +31,11 @@ const Connections = ({ loggedInAccount, accountFollowingList, profile, triggerGr
     setIsModalOpen(false);
   };
 
-  console.log('accountFollowing', accountFollowingList);
-
   return (
     <>
       <Flex gap={'large'}>
         <div>
-          <span className={styles.ConnectionsCount}>{accountFollowingList.length}</span>
+          <span className={styles.ConnectionsCount}>{curProfileConnections.length}</span>
           <span className={styles.ConnectionsOpenModal} onClick={() => showModal(ConnectionsType.FOLLOWING)}>
             Following
           </span>
@@ -48,7 +53,8 @@ const Connections = ({ loggedInAccount, accountFollowingList, profile, triggerGr
         handleCancel={handleCancel}
         triggerGraphRefresh={triggerGraphRefresh}
         loggedInAccount={loggedInAccount}
-        accountFollowingList={accountFollowingList}
+        loggedInAccountConnections={loggedInAccountConnections}
+        curProfileConnections={curProfileConnections}
         connectionsType={connectionsType}
         setConnectionsType={(type: ConnectionsType) => setConnectionsType(type)}
         profile={profile}

--- a/frontend/src/network/ConnectionsList.module.css
+++ b/frontend/src/network/ConnectionsList.module.css
@@ -1,7 +1,21 @@
 .root {
-  padding: 16px;
+  padding: 16px 0;
   display: flex;
   flex-direction: column;
   height: fit-content;
-  margin-right: 15px;
+}
+
+.ConnectionsCount {
+  font-weight: bold;
+  margin-right: 6px;
+  font-size: medium;
+}
+
+.ConnectionsOpenModal {
+  font-size: medium;
+}
+
+.ConnectionsOpenModal:hover {
+  text-decoration: underline;
+  cursor: pointer;
 }

--- a/frontend/src/network/ConnectionsList.tsx
+++ b/frontend/src/network/ConnectionsList.tsx
@@ -9,26 +9,24 @@ import { getContext } from '../service/AuthService';
 
 type ConnectionsListProps = {
   account: UserAccount;
-  accountFollowing: string[];
+  accountFollowingList: string[];
   graphRootUser: User;
   triggerGraphRefresh: () => void;
+  isModalOpen: boolean;
 };
 
 const ConnectionsList = ({
   account,
   graphRootUser,
-  accountFollowing,
+  accountFollowingList,
   triggerGraphRefresh,
+  isModalOpen,
 }: ConnectionsListProps): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [connectionsList, setConnectionsList] = useState<User[]>([]);
 
   const fetchConnections = async () => {
     const ctx = getContext();
-
-    const accountFollowingList = await dsnpLink.userFollowing(ctx, {
-      msaId: graphRootUser.msaId,
-    });
 
     const list: User[] = await Promise.all(
       accountFollowingList.map((msaId) =>
@@ -57,19 +55,18 @@ const ConnectionsList = ({
 
   // Update again when accountFollowing changes.
   useEffect(() => {
-    fetchConnections();
-  }, [graphRootUser, accountFollowing]);
+    if (isModalOpen) fetchConnections();
+  }, [graphRootUser, isModalOpen]);
 
   return (
     <Spin spinning={isLoading} tip="Loading" size="large">
       <div className={styles.root}>
-        <Title level={3}>Following ({connectionsList.length})</Title>
         <ConnectionsListProfiles
-          key={accountFollowing.length}
+          key={accountFollowingList.length}
           triggerGraphRefresh={triggerGraphRefresh}
           account={account}
           connectionsList={connectionsList}
-          accountFollowing={accountFollowing}
+          accountFollowingList={accountFollowingList}
         />
       </div>
     </Spin>

--- a/frontend/src/network/ConnectionsList.tsx
+++ b/frontend/src/network/ConnectionsList.tsx
@@ -55,7 +55,6 @@ const ConnectionsList = ({
 
   // Update again when accountFollowing changes.
   useEffect(() => {
-    console.log(profile);
     fetchConnections();
   }, [profile, loggedInAccountConnections, curProfileConnections]);
 

--- a/frontend/src/network/ConnectionsList.tsx
+++ b/frontend/src/network/ConnectionsList.tsx
@@ -8,19 +8,17 @@ import * as dsnpLink from '../dsnpLink';
 import { getContext } from '../service/AuthService';
 
 type ConnectionsListProps = {
-  account: UserAccount;
+  loggedInAccount: UserAccount;
   accountFollowingList: string[];
-  graphRootUser: User;
+  profile: User;
   triggerGraphRefresh: () => void;
-  isModalOpen: boolean;
 };
 
 const ConnectionsList = ({
-  account,
-  graphRootUser,
+  loggedInAccount,
+  profile,
   accountFollowingList,
   triggerGraphRefresh,
-  isModalOpen,
 }: ConnectionsListProps): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [connectionsList, setConnectionsList] = useState<User[]>([]);
@@ -32,11 +30,11 @@ const ConnectionsList = ({
       accountFollowingList.map((msaId) =>
         dsnpLink.getProfile(ctx, { msaId: msaId }).then(({ handle, fromId, content }) => {
           try {
-            const profile = content ? JSON.parse(content) : {};
+            const connectionProfile = content ? JSON.parse(content) : {};
             return {
               handle: handle!,
               msaId: fromId,
-              profile: profile,
+              profile: connectionProfile,
             };
           } catch (e) {
             console.error(e);
@@ -55,8 +53,8 @@ const ConnectionsList = ({
 
   // Update again when accountFollowing changes.
   useEffect(() => {
-    if (isModalOpen) fetchConnections();
-  }, [graphRootUser, isModalOpen]);
+    fetchConnections();
+  }, [profile]);
 
   return (
     <Spin spinning={isLoading} tip="Loading" size="large">
@@ -64,7 +62,7 @@ const ConnectionsList = ({
         <ConnectionsListProfiles
           key={accountFollowingList.length}
           triggerGraphRefresh={triggerGraphRefresh}
-          account={account}
+          loggedInAccount={loggedInAccount}
           connectionsList={connectionsList}
           accountFollowingList={accountFollowingList}
         />

--- a/frontend/src/network/ConnectionsList.tsx
+++ b/frontend/src/network/ConnectionsList.tsx
@@ -9,7 +9,8 @@ import { getContext } from '../service/AuthService';
 
 type ConnectionsListProps = {
   loggedInAccount: UserAccount;
-  accountFollowingList: string[];
+  loggedInAccountConnections: string[];
+  curProfileConnections: string[];
   profile: User;
   triggerGraphRefresh: () => void;
 };
@@ -17,7 +18,8 @@ type ConnectionsListProps = {
 const ConnectionsList = ({
   loggedInAccount,
   profile,
-  accountFollowingList,
+  loggedInAccountConnections,
+  curProfileConnections,
   triggerGraphRefresh,
 }: ConnectionsListProps): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -27,14 +29,14 @@ const ConnectionsList = ({
     const ctx = getContext();
 
     const list: User[] = await Promise.all(
-      accountFollowingList.map((msaId) =>
+      curProfileConnections.map((msaId) =>
         dsnpLink.getProfile(ctx, { msaId: msaId }).then(({ handle, fromId, content }) => {
           try {
-            const connectionProfile = content ? JSON.parse(content) : {};
+            const profile = content ? JSON.parse(content) : {};
             return {
               handle: handle!,
               msaId: fromId,
-              profile: connectionProfile,
+              profile: profile,
             };
           } catch (e) {
             console.error(e);
@@ -53,18 +55,19 @@ const ConnectionsList = ({
 
   // Update again when accountFollowing changes.
   useEffect(() => {
+    console.log(profile);
     fetchConnections();
-  }, [profile]);
+  }, [profile, loggedInAccountConnections, curProfileConnections]);
 
   return (
     <Spin spinning={isLoading} tip="Loading" size="large">
       <div className={styles.root}>
         <ConnectionsListProfiles
-          key={accountFollowingList.length}
+          key={loggedInAccountConnections.length}
           triggerGraphRefresh={triggerGraphRefresh}
           loggedInAccount={loggedInAccount}
           connectionsList={connectionsList}
-          accountFollowingList={accountFollowingList}
+          loggedInAccountConnections={loggedInAccountConnections}
         />
       </div>
     </Spin>

--- a/frontend/src/network/ConnectionsListProfiles.module.css
+++ b/frontend/src/network/ConnectionsListProfiles.module.css
@@ -8,4 +8,6 @@
   display: flex;
   flex: 1;
   cursor: pointer;
+  font-size: large;
+  font-weight: bold;
 }

--- a/frontend/src/network/ConnectionsListProfiles.tsx
+++ b/frontend/src/network/ConnectionsListProfiles.tsx
@@ -7,14 +7,14 @@ import styles from './ConnectionsListProfiles.module.css';
 import { useNavigate } from 'react-router-dom';
 
 interface ConnectionsListProfilesProps {
-  account: UserAccount;
+  loggedInAccount: UserAccount;
   connectionsList: User[];
   accountFollowingList: string[];
   triggerGraphRefresh: () => void;
 }
 
 const ConnectionsListProfiles = ({
-  account,
+  loggedInAccount,
   connectionsList,
   accountFollowingList,
   triggerGraphRefresh,
@@ -30,7 +30,7 @@ const ConnectionsListProfiles = ({
             <FromTitle user={user} />
           </div>
           {/* Skip change button for self */}
-          {user.msaId !== account.msaId && (
+          {user.msaId !== loggedInAccount.msaId && (
             <GraphChangeButton
               key={index}
               triggerGraphRefresh={triggerGraphRefresh}

--- a/frontend/src/network/ConnectionsListProfiles.tsx
+++ b/frontend/src/network/ConnectionsListProfiles.tsx
@@ -5,44 +5,47 @@ import { FromTitle } from '../content/FromTitle';
 import UserAvatar from '../chrome/UserAvatar';
 import styles from './ConnectionsListProfiles.module.css';
 import { useNavigate } from 'react-router-dom';
+import { Flex } from 'antd';
 
 interface ConnectionsListProfilesProps {
   loggedInAccount: UserAccount;
   connectionsList: User[];
-  accountFollowingList: string[];
+  loggedInAccountConnections: string[];
   triggerGraphRefresh: () => void;
 }
 
 const ConnectionsListProfiles = ({
   loggedInAccount,
   connectionsList,
-  accountFollowingList,
+  loggedInAccountConnections,
   triggerGraphRefresh,
 }: ConnectionsListProfilesProps): ReactElement => {
   const navigate = useNavigate();
 
   return (
-    <>
-      {connectionsList.map((user, index) => (
-        <div className={styles.profile} key={user.msaId}>
-          <UserAvatar user={user} avatarSize="small" />
-          <div className={styles.name} onClick={() => navigate(`/profile/${user.msaId}`)}>
-            <FromTitle user={user} />
+    <Flex gap={'small'} vertical>
+      {connectionsList.map((connectionAccount, index) => (
+        <div className={styles.profile} key={connectionAccount.msaId}>
+          <UserAvatar user={connectionAccount} avatarSize="small" />
+          <div className={styles.name} onClick={() => navigate(`/profile/${connectionAccount.msaId}`)}>
+            <FromTitle user={connectionAccount} />
           </div>
           {/* Skip change button for self */}
-          {user.msaId !== loggedInAccount.msaId && (
+          {connectionAccount.msaId !== loggedInAccount.msaId && (
             <GraphChangeButton
               key={index}
               triggerGraphRefresh={triggerGraphRefresh}
-              user={user}
+              connectionAccount={connectionAccount}
               relationshipStatus={
-                accountFollowingList.includes(user.msaId) ? RelationshipStatus.FOLLOWING : RelationshipStatus.NONE
+                loggedInAccountConnections.includes(connectionAccount.msaId)
+                  ? RelationshipStatus.FOLLOWING
+                  : RelationshipStatus.NONE
               }
             />
           )}
         </div>
       ))}
-    </>
+    </Flex>
   );
 };
 export default ConnectionsListProfiles;

--- a/frontend/src/network/ConnectionsListProfiles.tsx
+++ b/frontend/src/network/ConnectionsListProfiles.tsx
@@ -9,14 +9,14 @@ import { useNavigate } from 'react-router-dom';
 interface ConnectionsListProfilesProps {
   account: UserAccount;
   connectionsList: User[];
-  accountFollowing: string[];
+  accountFollowingList: string[];
   triggerGraphRefresh: () => void;
 }
 
 const ConnectionsListProfiles = ({
   account,
   connectionsList,
-  accountFollowing,
+  accountFollowingList,
   triggerGraphRefresh,
 }: ConnectionsListProfilesProps): ReactElement => {
   const navigate = useNavigate();
@@ -36,7 +36,7 @@ const ConnectionsListProfiles = ({
               triggerGraphRefresh={triggerGraphRefresh}
               user={user}
               relationshipStatus={
-                accountFollowing.includes(user.msaId) ? RelationshipStatus.FOLLOWING : RelationshipStatus.NONE
+                accountFollowingList.includes(user.msaId) ? RelationshipStatus.FOLLOWING : RelationshipStatus.NONE
               }
             />
           )}

--- a/frontend/src/network/ConnectionsModal.module.css
+++ b/frontend/src/network/ConnectionsModal.module.css
@@ -1,0 +1,7 @@
+.title {
+    font-size: x-large;
+    text-align: center;
+    font-weight: bold;
+    width: 100%;
+    display: block;
+}

--- a/frontend/src/network/ConnectionsModal.module.css
+++ b/frontend/src/network/ConnectionsModal.module.css
@@ -1,7 +1,7 @@
 .title {
-    font-size: x-large;
-    text-align: center;
-    font-weight: bold;
-    width: 100%;
-    display: block;
+  font-size: x-large;
+  text-align: center;
+  font-weight: bold;
+  width: 100%;
+  display: block;
 }

--- a/frontend/src/network/ConnectionsModal.tsx
+++ b/frontend/src/network/ConnectionsModal.tsx
@@ -8,9 +8,9 @@ import styles from './ConnectionsModal.module.css';
 interface ConnectionsModalProps {
   isModalOpen: boolean;
   handleCancel: () => void;
-  account: UserAccount;
+  loggedInAccount: UserAccount;
   accountFollowingList: string[];
-  graphRootUser: User;
+  profile: User;
   triggerGraphRefresh: () => void;
   connectionsType: ConnectionsType;
   setConnectionsType: (type: ConnectionsType) => void;
@@ -19,9 +19,9 @@ interface ConnectionsModalProps {
 const ConnectionsModal = ({
   isModalOpen,
   handleCancel,
-  account,
+  loggedInAccount,
   accountFollowingList,
-  graphRootUser,
+  profile,
   triggerGraphRefresh,
   connectionsType,
   setConnectionsType,
@@ -36,11 +36,10 @@ const ConnectionsModal = ({
       ),
       children: (
         <ConnectionsList
-          account={account}
+          loggedInAccount={loggedInAccount}
           accountFollowingList={accountFollowingList}
-          graphRootUser={graphRootUser}
+          profile={profile}
           triggerGraphRefresh={triggerGraphRefresh}
-          isModalOpen={isModalOpen}
         />
       ),
     },
@@ -53,7 +52,7 @@ const ConnectionsModal = ({
 
   return (
     <Modal
-      title={<span className={styles.title}>{makeDisplayHandle(account.handle)}</span>}
+      title={<span className={styles.title}>{makeDisplayHandle(profile.handle)}</span>}
       open={isModalOpen}
       onCancel={handleCancel}
       okButtonProps={{ style: { display: 'none' } }}

--- a/frontend/src/network/ConnectionsModal.tsx
+++ b/frontend/src/network/ConnectionsModal.tsx
@@ -1,0 +1,72 @@
+import { Modal, Tabs, TabsProps } from 'antd';
+import React from 'react';
+import ConnectionsList from './ConnectionsList';
+import { ConnectionsType, User, UserAccount } from '../types';
+import { makeDisplayHandle } from '../helpers/DisplayHandle';
+import styles from './ConnectionsModal.module.css';
+
+interface ConnectionsModalProps {
+  isModalOpen: boolean;
+  handleCancel: () => void;
+  account: UserAccount;
+  accountFollowingList: string[];
+  graphRootUser: User;
+  triggerGraphRefresh: () => void;
+  connectionsType: ConnectionsType;
+  setConnectionsType: (type: ConnectionsType) => void;
+}
+
+const ConnectionsModal = ({
+  isModalOpen,
+  handleCancel,
+  account,
+  accountFollowingList,
+  graphRootUser,
+  triggerGraphRefresh,
+  connectionsType,
+  setConnectionsType,
+}: ConnectionsModalProps) => {
+  const tabsData: TabsProps['items'] = [
+    {
+      key: ConnectionsType.FOLLOWING,
+      label: (
+        <span>
+          Following <b>{accountFollowingList.length}</b>
+        </span>
+      ),
+      children: (
+        <ConnectionsList
+          account={account}
+          accountFollowingList={accountFollowingList}
+          graphRootUser={graphRootUser}
+          triggerGraphRefresh={triggerGraphRefresh}
+          isModalOpen={isModalOpen}
+        />
+      ),
+    },
+    {
+      key: ConnectionsType.FOLLOWERS,
+      label: 'Followers',
+      children: <div>It is up to the provider to maintain a database and reverse map and save the followers list.</div>,
+    },
+  ];
+
+  return (
+    <Modal
+      title={<span className={styles.title}>{makeDisplayHandle(account.handle)}</span>}
+      open={isModalOpen}
+      onCancel={handleCancel}
+      okButtonProps={{ style: { display: 'none' } }}
+      cancelButtonProps={{ style: { display: 'none' } }}
+    >
+      <Tabs
+        activeKey={connectionsType}
+        items={tabsData}
+        onTabClick={(key) => setConnectionsType(key as ConnectionsType)}
+        size={'large'}
+      />
+    </Modal>
+  );
+};
+
+export default ConnectionsModal;

--- a/frontend/src/network/ConnectionsModal.tsx
+++ b/frontend/src/network/ConnectionsModal.tsx
@@ -9,7 +9,8 @@ interface ConnectionsModalProps {
   isModalOpen: boolean;
   handleCancel: () => void;
   loggedInAccount: UserAccount;
-  accountFollowingList: string[];
+  loggedInAccountConnections: string[];
+  curProfileConnections: string[];
   profile: User;
   triggerGraphRefresh: () => void;
   connectionsType: ConnectionsType;
@@ -20,7 +21,8 @@ const ConnectionsModal = ({
   isModalOpen,
   handleCancel,
   loggedInAccount,
-  accountFollowingList,
+  loggedInAccountConnections,
+  curProfileConnections,
   profile,
   triggerGraphRefresh,
   connectionsType,
@@ -31,13 +33,14 @@ const ConnectionsModal = ({
       key: ConnectionsType.FOLLOWING,
       label: (
         <span>
-          Following <b>{accountFollowingList.length}</b>
+          Following <b>{curProfileConnections.length}</b>
         </span>
       ),
       children: (
         <ConnectionsList
           loggedInAccount={loggedInAccount}
-          accountFollowingList={accountFollowingList}
+          loggedInAccountConnections={loggedInAccountConnections}
+          curProfileConnections={curProfileConnections}
           profile={profile}
           triggerGraphRefresh={triggerGraphRefresh}
         />

--- a/frontend/src/network/GraphChangeButton.tsx
+++ b/frontend/src/network/GraphChangeButton.tsx
@@ -6,12 +6,16 @@ import { RelationshipStatus, User } from '../types';
 import { getContext } from '../service/AuthService';
 
 interface GraphChangeButtonProps {
-  user: User;
+  connectionAccount: User;
   relationshipStatus: RelationshipStatus;
   triggerGraphRefresh: () => void;
 }
 
-const GraphChangeButton = ({ user, relationshipStatus, triggerGraphRefresh }: GraphChangeButtonProps): ReactElement => {
+const GraphChangeButton = ({
+  connectionAccount,
+  relationshipStatus,
+  triggerGraphRefresh,
+}: GraphChangeButtonProps): ReactElement => {
   const [isUpdating, setIsUpdating] = React.useState<boolean>(false);
 
   const isFollowing = relationshipStatus === RelationshipStatus.FOLLOWING;
@@ -21,9 +25,9 @@ const GraphChangeButton = ({ user, relationshipStatus, triggerGraphRefresh }: Gr
   const changeGraphState = async () => {
     setIsUpdating(true);
     if (isFollowing) {
-      await dsnpLink.graphUnfollow(getContext(), { msaId: user.msaId });
+      await dsnpLink.graphUnfollow(getContext(), { msaId: connectionAccount.msaId });
     } else {
-      await dsnpLink.graphFollow(getContext(), { msaId: user.msaId });
+      await dsnpLink.graphFollow(getContext(), { msaId: connectionAccount.msaId });
     }
     // Defined in App.tsx to refreshFollowing, triggers an api call to /graph/{msaId}/following
     triggerGraphRefresh();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -35,3 +35,8 @@ export enum RelationshipStatus {
   FOLLOWING,
   NONE,
 }
+
+export enum ConnectionsType {
+  FOLLOWERS = 'FOLLOWERS',
+  FOLLOWING = 'FOLLOWING',
+}


### PR DESCRIPTION
# Purpose
The goal of this PR is to create a modal and add a followers section to profile.

Closes #79 

## Solution

After exploring how to solve this ticket and talking with @enddynayn and @JoeCap08055 we decided to keep the followers section in the modal but instruct the user on what they need to do in order to get a list of followes, since it is not something that we store in a user's graph.


### Change summary
* Added modal
* Added styling
* Changed profile UI for how we display followers and following count.


## Steps to Verify
1. Check that following displays the correct number of users and user profiles.
2. Follow/Unfollow and watch it update.
3. Note: The spinner UI for follow/unfollow is not yet connected to the webhook, so it's a little buggy, but @JoeCap08055 created a ticket to add this.


## Additional details / screenshot

https://github.com/user-attachments/assets/cf3c9d88-4a92-4f99-ae4f-2888a58c13c4

