### PR TITLE
navigate to explore on login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,13 +62,7 @@ const App = (): ReactElement => {
     >
       <BrowserRouter>
         <Layout className={styles.root}>
-          <Header
-            loggedInAccount={loggedInAccount}
-            logout={handleLogout}
-            login={(account: UserAccount, providerInfo: dsnpLink.ProviderResponse) =>
-              handleLogin(account, providerInfo)
-            }
-          />
+          <Header loggedInAccount={loggedInAccount} logout={handleLogout} login={handleLogin} />
           <div className={styles.block}>
             <Content className={styles.content}>
               <Spin spinning={loading}>

--- a/frontend/src/chrome/Header.tsx
+++ b/frontend/src/chrome/Header.tsx
@@ -26,6 +26,11 @@ const Header = ({ loggedInAccount, login, logout }: HeaderProps): ReactElement =
     }
   };
 
+  const handleLogin = (account: UserAccount, providerInfo: dsnpLink.ProviderResponse) => {
+    navigate('/');
+    login(account, providerInfo);
+  };
+
   return (
     <div className={styles.root}>
       <Flex align={'center'} justify={'space-between'} className={styles.container}>
@@ -43,7 +48,7 @@ const Header = ({ loggedInAccount, login, logout }: HeaderProps): ReactElement =
             {makeDisplayHandle(loggedInAccount.handle)}
           </Popover>
         ) : (
-          <LoginScreen onLogin={login} />
+          <LoginScreen onLogin={handleLogin} />
         )}
       </Flex>
     </div>


### PR DESCRIPTION
# Purpose
The goal of this PR is make sure that on login we're always redirected to the explore page ('/').

Closes #82 

## Solution

On call of login() navigate to '/'

### Change summary
* add navigate call


## Steps to Verify
1. on login, you always land on the home page.
