### PR TITLE
106 fix navigation bugs when not logged in

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import useStickyState from './helpers/StickyState';
 import * as dsnpLink from './dsnpLink';
 import { Network, UserAccount } from './types';
 import Header from './chrome/Header';
-import { Col, ConfigProvider, Layout, Row, Spin } from 'antd';
+import { Col, ConfigProvider, Layout, Modal, Row, Spin } from 'antd';
 import { setAccessToken } from './service/AuthService';
 import { Content } from 'antd/es/layout/layout';
 import { setIpfsGateway } from './service/IpfsService';
@@ -15,6 +15,7 @@ import FrequencyWaves from './style/frequencyWaves.svg';
 import FeedNav from './content/FeedNav';
 import { BrowserRouter } from 'react-router-dom';
 import PageRoutes from './PageRoutes';
+import LoginModal from './chrome/LoginModal';
 
 const App = (): ReactElement => {
   const [loggedInAccount, setLoggedInAccount] = useStickyState<UserAccount | undefined>(undefined, 'user-account');
@@ -22,6 +23,7 @@ const App = (): ReactElement => {
   const [network, setNetwork] = useState<Network>('testnet');
   const [isPosting, setIsPosting] = useState<boolean>(false);
   const [refreshTrigger, setRefreshTrigger] = useState<number>(Date.now());
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState<boolean>(false);
 
   if (loggedInAccount) {
     setAccessToken(loggedInAccount.accessToken, loggedInAccount.expires);
@@ -46,6 +48,10 @@ const App = (): ReactElement => {
       setRefreshTrigger(Date.now());
       setIsPosting(false);
     }, 14_000);
+  };
+
+  const handleCancel = () => {
+    setIsLoginModalOpen(false);
   };
 
   return (
@@ -83,12 +89,14 @@ const App = (): ReactElement => {
                         network={network}
                         isPosting={isPosting}
                         refreshTrigger={refreshTrigger}
+                        showLoginModal={() => setIsLoginModalOpen(true)}
                       />
                     </AuthErrorBoundary>
                   </Col>
                 </Row>
               </Spin>
             </Content>
+            <LoginModal open={isLoginModalOpen} onLogin={handleLogin} handleCancel={handleCancel} />
           </div>
           <img src={FrequencyWaves} alt={'Frequency Waves'} className={styles.waves} />
         </Layout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import styles from './App.module.css';
 
 import useStickyState from './helpers/StickyState';
@@ -53,6 +53,10 @@ const App = (): ReactElement => {
   const handleCancel = () => {
     setIsLoginModalOpen(false);
   };
+
+  useEffect(() => {
+    if (loggedInAccount) setIsLoginModalOpen(false);
+  }, [loggedInAccount]);
 
   return (
     <ConfigProvider

--- a/frontend/src/Feed.tsx
+++ b/frontend/src/Feed.tsx
@@ -11,6 +11,7 @@ type FeedProps = {
   feedType: FeedTypes;
   refreshTrigger: number;
   showReplyInput?: boolean;
+  showLoginModal?: () => void;
 };
 
 const Feed = ({
@@ -20,6 +21,7 @@ const Feed = ({
   feedType,
   refreshTrigger,
   showReplyInput = true,
+  showLoginModal,
 }: FeedProps): ReactElement => {
   return (
     <div className={styles.root}>
@@ -30,6 +32,7 @@ const Feed = ({
         feedType={feedType}
         profile={profile}
         showReplyInput={showReplyInput}
+        showLoginModal={showLoginModal}
       />
     </div>
   );

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -9,9 +9,10 @@ interface PageRoutesProps {
   network: Network;
   isPosting: boolean;
   refreshTrigger: number;
+  showLoginModal: () => void;
 }
 
-const PageRoutes = ({ loggedInAccount, network, isPosting, refreshTrigger }: PageRoutesProps) => {
+const PageRoutes = ({ loggedInAccount, network, isPosting, refreshTrigger, showLoginModal }: PageRoutesProps) => {
   return (
     <>
       <Routes>
@@ -24,6 +25,7 @@ const PageRoutes = ({ loggedInAccount, network, isPosting, refreshTrigger }: Pag
               isPosting={isPosting}
               refreshTrigger={refreshTrigger}
               showReplyInput={!!loggedInAccount}
+              showLoginModal={showLoginModal}
             />
           }
         />

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import Feed from './Feed';
 import { FeedTypes, Network, UserAccount } from './types';
 import ProfilePage from './chrome/ProfilePage';
@@ -29,28 +29,32 @@ const PageRoutes = ({ loggedInAccount, network, isPosting, refreshTrigger, showL
             />
           }
         />
-        <Route
-          path="/my-feed"
-          element={
-            <Feed
-              network={network}
-              feedType={FeedTypes.MY_FEED}
-              isPosting={isPosting}
-              refreshTrigger={refreshTrigger}
+        {loggedInAccount && (
+          <>
+            <Route
+              path="/my-feed"
+              element={
+                <Feed
+                  network={network}
+                  feedType={FeedTypes.MY_FEED}
+                  isPosting={isPosting}
+                  refreshTrigger={refreshTrigger}
+                />
+              }
             />
-          }
-        />
-        <Route
-          path="/profile/:dsnpId"
-          element={
-            <ProfilePage
-              network={network}
-              refreshTrigger={refreshTrigger}
-              isPosting={isPosting}
-              loggedInAccount={loggedInAccount}
+            <Route
+              path="/profile/:dsnpId"
+              element={
+                <ProfilePage
+                  network={network}
+                  refreshTrigger={refreshTrigger}
+                  isPosting={isPosting}
+                  loggedInAccount={loggedInAccount}
+                />
+              }
             />
-          }
-        />
+          </>
+        )}
       </Routes>
     </>
   );

--- a/frontend/src/chrome/LoginModal.module.css
+++ b/frontend/src/chrome/LoginModal.module.css
@@ -1,4 +1,4 @@
 .title {
-    font-weight: bold;
-    font-size: large;
+  font-weight: bold;
+  font-size: large;
 }

--- a/frontend/src/chrome/LoginModal.module.css
+++ b/frontend/src/chrome/LoginModal.module.css
@@ -1,0 +1,4 @@
+.title {
+    font-weight: bold;
+    font-size: large;
+}

--- a/frontend/src/chrome/LoginModal.tsx
+++ b/frontend/src/chrome/LoginModal.tsx
@@ -1,0 +1,29 @@
+import { Modal } from 'antd';
+import Login from '../login/Login';
+import React, { useState } from 'react';
+import { UserAccount } from '../types';
+import * as dsnpLink from '../dsnpLink';
+import LoginScreen from '../login/LoginScreen';
+
+interface LoginModalProps {
+  open: boolean;
+  onLogin: (account: UserAccount, providerInfo: dsnpLink.ProviderResponse) => void;
+  handleCancel: () => void;
+}
+
+const LoginModal = ({ open, onLogin, handleCancel }: LoginModalProps) => {
+  const [loadingState, setLoadingState] = useState<boolean>();
+
+  const onCancel = () => {
+    handleCancel();
+    setLoadingState(false);
+  };
+
+  return (
+    <Modal open={open} title={'To proceed, please login.'} footer={null} onCancel={onCancel}>
+      <LoginScreen onLogin={onLogin} loadingState={loadingState} />
+    </Modal>
+  );
+};
+
+export default LoginModal;

--- a/frontend/src/chrome/LoginModal.tsx
+++ b/frontend/src/chrome/LoginModal.tsx
@@ -1,9 +1,9 @@
 import { Modal } from 'antd';
-import Login from '../login/Login';
 import React, { useState } from 'react';
 import { UserAccount } from '../types';
 import * as dsnpLink from '../dsnpLink';
 import LoginScreen from '../login/LoginScreen';
+import styles from './LoginModal.module.css';
 
 interface LoginModalProps {
   open: boolean;
@@ -20,7 +20,12 @@ const LoginModal = ({ open, onLogin, handleCancel }: LoginModalProps) => {
   };
 
   return (
-    <Modal open={open} title={'To proceed, please login.'} footer={null} onCancel={onCancel}>
+    <Modal
+      open={open}
+      title={<span className={styles.title}>To proceed, please login.</span>}
+      footer={null}
+      onCancel={onCancel}
+    >
       <LoginScreen onLogin={onLogin} loadingState={loadingState} />
     </Modal>
   );

--- a/frontend/src/content/FromTitle.tsx
+++ b/frontend/src/content/FromTitle.tsx
@@ -9,16 +9,21 @@ interface FromTitleProps {
   user: User;
   level?: 1 | 2 | 3 | 4;
   isReply?: boolean;
+  isLoggedOut?: boolean;
+  showLoginModal?: () => void;
 }
 
-export const FromTitle = ({ user, isReply, level }: FromTitleProps): ReactElement => {
+export const FromTitle = ({ user, isReply, level, isLoggedOut, showLoginModal }: FromTitleProps): ReactElement => {
   const navigate = useNavigate();
 
   const primary = makeDisplayHandle(user.handle);
   const secondary = user?.profile?.name || '';
 
   return (
-    <div onClick={() => navigate(`/profile/${user.msaId}`)} className={styles.root}>
+    <div
+      onClick={() => (isLoggedOut ? navigate(`/profile/${user.msaId}`) : showLoginModal && showLoginModal())}
+      className={styles.root}
+    >
       {level && (
         <Title style={{ margin: 0 }} level={level}>
           {primary}

--- a/frontend/src/content/Post.tsx
+++ b/frontend/src/content/Post.tsx
@@ -20,9 +20,10 @@ type PostProps = {
   feedItem: FeedItem;
   showReplyInput: boolean;
   isProfile?: boolean;
+  showLoginModal?: () => void;
 };
 
-const Post = ({ feedItem, showReplyInput, isProfile }: PostProps): ReactElement => {
+const Post = ({ feedItem, showReplyInput, isProfile, showLoginModal }: PostProps): ReactElement => {
   const navigate = useNavigate();
   const { user, isLoading } = useGetUser(feedItem.fromId);
 
@@ -36,11 +37,16 @@ const Post = ({ feedItem, showReplyInput, isProfile }: PostProps): ReactElement 
     <Card key={feedItem.contentHash} className={styles.card} bordered={true}>
       <Spin tip="Loading" size="large" spinning={isLoading}>
         {!isProfile && (
-          <div onClick={() => navigate(`/profile/${feedItem.fromId}`)} className={styles.metaBlock}>
+          <div
+            onClick={() =>
+              showReplyInput ? navigate(`/profile/${feedItem.fromId}`) : showLoginModal && showLoginModal()
+            }
+            className={styles.metaBlock}
+          >
             <Card.Meta
               className={styles.metaInnerBlock}
               avatar={<UserAvatar user={user} avatarSize={'medium'} />}
-              title={<FromTitle user={user} />}
+              title={<FromTitle user={user} showLoginModal={showLoginModal} isLoggedOut={showReplyInput} />}
             />
           </div>
         )}

--- a/frontend/src/content/PostList.tsx
+++ b/frontend/src/content/PostList.tsx
@@ -22,11 +22,19 @@ type PostListProps = {
   refreshTrigger: number;
   network: Network;
   showReplyInput: boolean;
+  showLoginModal?: () => void;
 };
 
 type FeedItem = dsnpLink.BroadcastExtended;
 
-const PostList = ({ feedType, profile, refreshTrigger, network, showReplyInput }: PostListProps): ReactElement => {
+const PostList = ({
+  feedType,
+  profile,
+  refreshTrigger,
+  network,
+  showReplyInput,
+  showLoginModal,
+}: PostListProps): ReactElement => {
   const [priorTrigger, setPriorTrigger] = React.useState<number>(refreshTrigger);
   const [priorFeedType, setPriorFeedType] = React.useState<number>(feedType);
   const [priorFeed, setPriorFeed] = React.useState<FeedItem[]>([]);
@@ -129,6 +137,7 @@ const PostList = ({ feedType, profile, refreshTrigger, network, showReplyInput }
               feedItem={feedItem}
               showReplyInput={showReplyInput}
               isProfile={feedType === FeedTypes.MY_PROFILE || feedType === FeedTypes.OTHER_PROFILE}
+              showLoginModal={showLoginModal}
             />
           ))}
           <Space />

--- a/frontend/src/login/Login.tsx
+++ b/frontend/src/login/Login.tsx
@@ -111,7 +111,8 @@ const Login = ({ onLogin, providerId, nodeUrl, siwfUrl }: LoginProps): ReactElem
           accountResp.handle = resp.handle;
         } catch (e) {
           console.error(`Login.tsx::handleLogin: dsnpLink.authAccount: error: ${e}`);
-          throw new Error(`Account Sign In Failed: (${e})`);
+          setIsLoading(false);
+          return;
         }
         onLogin({
           handle: accountResp.handle,
@@ -143,7 +144,8 @@ const Login = ({ onLogin, providerId, nodeUrl, siwfUrl }: LoginProps): ReactElem
               });
             } catch (e) {
               console.error(`Login.tsx::getMsaIdAndHandle: dsnpLink.authAccount: error: ${e}`);
-              throw new Error(`Account Sign In Failed: (${e})`);
+              setIsLoading(false);
+              return;
             }
 
             if (resp.size === 0) {

--- a/frontend/src/login/LoginScreen.tsx
+++ b/frontend/src/login/LoginScreen.tsx
@@ -12,11 +12,12 @@ const dsnpLinkCtx = process.env.REACT_APP_BACKEND_URL
 
 interface LoginScreenProps {
   onLogin: (account: UserAccount, providerInfo: dsnpLink.ProviderResponse) => void;
+  loadingState?: boolean;
 }
 
-const LoginScreen = ({ onLogin }: LoginScreenProps): ReactElement => {
+const LoginScreen = ({ onLogin, loadingState = true }: LoginScreenProps): ReactElement => {
   // Assume it has a wallet extension until after we have called enable
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState<boolean>(loadingState);
   const [providerInfo, setProviderInfo] = useState<dsnpLink.ProviderResponse>();
 
   useEffect(() => {


### PR DESCRIPTION
# Purpose
The goal of this PR is to better handle navigation and login errors when not logged in.

Closes #106 

## Solution

- When login is canceled, stop loading and don't throw error.
- If user tries to click on a profile while not logged in, a login modal opens.


### Change summary
* Implemented above solutions


## Steps to Verify
1. Logout
2. Try to click on user through the avatar in a post
3. see login modal pop up
4. login through modal
5. should be able to navigate everywhere
6. logout
7. login through header button


## Additional details / screenshot

<img width="971" alt="Screenshot 2024-07-16 at 12 09 01 PM" src="https://github.com/user-attachments/assets/a78a1e84-be80-48da-ade6-838c39bfed31">
