### PR TITLE
discover posts persist

### DIFF
--- a/frontend/src/content/PostList.tsx
+++ b/frontend/src/content/PostList.tsx
@@ -71,7 +71,7 @@ const PostList = ({ feedType, profile, refreshTrigger, network, showReplyInput }
   useEffect(() => {
     const getOlder = refreshTrigger === priorTrigger;
     fetchData(getOlder);
-  }, [feedType, profile, refreshTrigger, priorTrigger, network]);
+  }, [feedType, profile, refreshTrigger, priorTrigger]);
 
   const fetchData = async (getOlder: boolean) => {
     const isAddingMore = priorFeedType === feedType;


### PR DESCRIPTION
# Purpose
The goal of this PR is to see discover posts before and after login

Closes #109 

## Solution

Check to see what is causing the rerender and fix the bug.

### Change summary
* Removed network from the useEffect that gets posts.


## Steps to Verify
1. Logout
2. See feed
3. login
4. still see feed