### PR TITLE
Update startup script and docker-compose files for testnet connection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,8 @@ x-content-publishing-env: &content-publishing-env
   BATCH_INTERVAL_SECONDS: 12
   BATCH_MAX_COUNT: 1000
   ASSET_UPLOAD_VERIFICATION_DELAY_SECONDS: 5
+  IPFS_BASIC_AUTH_USER:
+  IPFS_BASIC_AUTH_SECRET:
 
 x-content-watcher-env: &content-watcher-env
   IPFS_BASIC_AUTH_SECRET:
@@ -101,6 +103,7 @@ services:
   content-publishing-service-api:
     image: amplicalabs/content-publishing-service:latest
     platform: linux/amd64
+    pull_policy: always
     ports:
     - ${SERVICE_PORT_0}:3000
     environment:
@@ -114,6 +117,7 @@ services:
   content-publishing-service-worker:
     image: amplicalabs/content-publishing-service:latest
     platform: linux/amd64
+    pull_policy: always
     environment:
       <<: [*common-environment, *content-publishing-env]
       START_PROCESS: worker
@@ -126,6 +130,7 @@ services:
   content-watcher-service:
     image: amplicalabs/content-watcher-service:latest
     platform: linux/amd64
+    pull_policy: always
     ports:
     - ${SERVICE_PORT_1}:3000
     environment:
@@ -139,6 +144,7 @@ services:
   graph-service-api:
     image: amplicalabs/graph-service:latest
     platform: linux/amd64
+    pull_policy: always
     ports:
     - ${SERVICE_PORT_2}:3000
     environment:
@@ -152,6 +158,7 @@ services:
   graph-service-worker:
     image: amplicalabs/graph-service:latest
     platform: linux/amd64
+    pull_policy: always
     environment:
       <<: [*common-environment, *graph-service-env]
       START_PROCESS: worker
@@ -163,6 +170,7 @@ services:
   account-service-api:
     image: amplicalabs/account-service:latest
     platform: linux/amd64
+    pull_policy: always
     ports:
     - ${SERVICE_PORT_3}:3000
     command: api
@@ -176,6 +184,7 @@ services:
   account-service-worker:
     image: amplicalabs/account-service:latest
     platform: linux/amd64
+    pull_policy: always
     command: worker
     environment:
       <<: [*common-environment, *account-service-env]

--- a/frontend/src/login/Login.tsx
+++ b/frontend/src/login/Login.tsx
@@ -160,7 +160,8 @@ const Login = ({ onLogin, providerId, nodeUrl, siwfUrl }: LoginProps): ReactElem
       console.log(`Start polling for SIWF account creation... timeout:(0)`);
       let SIWFAccountResp = await getMsaIdAndHandle(referenceId, 0);
       let tries = 1;
-      while (SIWFAccountResp === null && tries < 10) {
+      // Increase the timeout to 90 (30 * 3) seconds to allow for the account creation to complete
+      while (SIWFAccountResp === null && tries < 30) {
         console.log('Waiting another 3 seconds before getting the account again...');
         SIWFAccountResp = await getMsaIdAndHandle(referenceId, 3_000);
         tries++;

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -12,7 +12,7 @@ ask_and_save() {
 }
 
 # Check for Docker and Docker Compose
-if ! command -v docker &> /dev/null || ! command -v docker-compose &> /dev/null; then
+if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
     printf "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
     exit 1
 fi
@@ -20,9 +20,9 @@ fi
 # Load existing .env-saved file if it exists
 if [ -f .env-saved ]; then
     cat << EOI
-****************************************************************************************
-* Loading existing .env-saved file environment values...                             *
-****************************************************************************************
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Loading existing .env-saved file environment values...                                      ┃ 
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 EOI
 else 
@@ -37,9 +37,9 @@ else
 
     # Create .env-saved file to store environment variables
     cat << EOI
-****************************************************************************************
-* Creating .env-saved file to store environment variables...                         *
-****************************************************************************************
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Creating .env-saved file to store environment variables...                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 EOI
     echo "COMPOSE_PROJECT_NAME='gateway'" >> .env-saved
@@ -81,7 +81,7 @@ EOI
 
     ask_and_save "FREQUENCY_URL" "Enter the Frequency Testnet RPC URL" "$FREQUENCY_URL"
     ask_and_save "FREQUENCY_HTTP_URL" "Enter the Frequency HTTP Testnet RPC URL" "$FREQUENCY_HTTP_URL"
-    cat << EOI
+cat << EOI
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃   🔗💠📡                                                                           📡💠🔗   ┃
@@ -127,9 +127,17 @@ then
 
     # Run npm run local:init 
     echo "Running npm run local:init to provision Provider with capacity, etc..."
-    cd backend && npm run local:init && cd -
+    cd backend && npm run local:init && cd ..
 fi
 
 # Start all services in detached mode
 echo -e "\nStarting all services..."
 docker compose  --profile backend --profile frontend up -d
+
+cat << EOI
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ 🚀 You can access the Gateway at http://localhost:3000/ 🚀                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+EOI
+

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -50,7 +50,14 @@ EOI
 
     if [[ $TESTNET_ENV =~ ^[Yy]$ ]]
     then
-        echo -e "\nStarting on testnet..."
+    cat << EOI
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Setting defaults for testnet...                                                             ┃ 
+┃ Hit <ENTER> to accept the default value or enter new value and then hit <ENTER>             ┃ 
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+EOI
         TESTNET_ENV="testnet"
         FREQUENCY_URL="wss://0.rpc.testnet.amplica.io"
         FREQUENCY_HTTP_URL="https://0.rpc.testnet.amplica.io"
@@ -66,19 +73,45 @@ EOI
         PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
         IPFS_VOLUME="/data/ipfs"
     fi
+    IPFS_ENDPOINT="http://ipfs:5001"
+    IPFS_GATEWAY_URL='https://ipfs.io/ipfs/[CID]'
+    IPFS_BASIC_AUTH_USER=""
+    IPFS_BASIC_AUTH_SECRET=""
+
 
     ask_and_save "FREQUENCY_URL" "Enter the Frequency Testnet RPC URL" "$FREQUENCY_URL"
     ask_and_save "FREQUENCY_HTTP_URL" "Enter the Frequency HTTP Testnet RPC URL" "$FREQUENCY_HTTP_URL"
     cat << EOI
 
-*************************************************************************************************
-* A Provider is required to start the services.                                                 *
-* If you need to become a provider, visit https://provider.frequency.xyz/ to get a Provider ID. *
-*************************************************************************************************
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃   🔗💠📡                                                                           📡💠🔗   ┃
+┃   🔗💠📡   A Provider is required to start the services.                           📡💠🔗   ┃
+┃   🔗💠📡                                                                           📡💠🔗   ┃
+┃   🔗💠📡   If you need to become a provider, visit                                 📡💠🔗   ┃
+┃   🔗💠📡   https://provider.frequency.xyz/ to get a Provider ID.                   📡💠🔗   ┃
+┃   🔗💠📡                                                                           📡💠🔗   ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
 EOI
     ask_and_save "PROVIDER_ID" "Enter Provider ID" "$PROVIDER_ID"
     ask_and_save "PROVIDER_ACCOUNT_SEED_PHRASE" "Enter Provider Seed Phrase" "$PROVIDER_ACCOUNT_SEED_PHRASE"
-    ask_and_save "IPFS_VOLUME" "Enter the IPFS volume" "$IPFS_VOLUME"
+    cat << EOI
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Do you want to change the IPFS settings [y/n]:                                              ┃ 
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+EOI
+    read CHANGE_IPFS_SETTINGS
+
+    if [[ $CHANGE_IPFS_SETTINGS =~ ^[Yy]$ ]]
+    then
+        ask_and_save "IPFS_VOLUME" "Enter the IPFS volume" "$IPFS_VOLUME"
+        ask_and_save "IPFS_ENDPOINT" "Enter the IPFS Endpoint" "kubo default: $IPFS_ENDPOINT"
+        ask_and_save "IPFS_GATEWAY_URL" "Enter the IPFS Gateway URL" "default public ipfs: $IPFS_GATEWAY_URL"
+        ask_and_save "IPFS_BASIC_AUTH_USER" "Enter the IPFS Basic Auth User" "$IPFS_BASIC_AUTH_USER"
+        ask_and_save "IPFS_BASIC_AUTH_SECRET" "Enter the IPFS Basic Auth Secret" "$IPFS_BASIC_AUTH_SECRET"
+    fi
 fi
 set -a; source .env-saved; set +a
 


### PR DESCRIPTION
# Purpose
The goal of this PR is to update the `start-gateway.sh` script to allow editing the IPFS environment variables.

## Solution

Add a new path to the script which first asks the user if they would like to change the IPFS settings and then collects the settings and saves them in the `.env-saved` file.

### Change summary
- `docker-compose.yaml` updated `pull_policy` to `always` to ensure that the latest published micro-service container is always pulled.
- `start-gateway.sh` updated as per solution.
- `/frontend/Login.tsx` updated to increase account creation timeout to 90 seconds to allow for block finalization delay on testnet.

## Steps to Verify
1. Execute `start-gateway.sh` and verify that IPFS values are able to be changed.
2. `rm .env-saved` to go through the questions again.
