### PR TITLE
fix: initiate search for content at startup instead of resetting scan

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -21,8 +21,7 @@ import logger from './logger';
 import { WebhookController } from './controllers/WebhookController';
 import { ContentWatcherService } from './services/ContentWatcherService';
 import { AnnouncementType } from './types/content-announcement';
-import { GraphWebhookService } from './services/GraphWebhookService';
-import { GraphService } from './services/GraphService';
+import { randomUUID } from 'crypto';
 
 // Support BigInt JSON
 (BigInt.prototype as any).toJSON = function () {
@@ -94,7 +93,11 @@ ContentWatcherService.getInstance().then(async (service) => {
       .map((v) => v as AnnouncementType)
   );
 
-  service.resetScanner({ immediate: true, rewindOffset: 600 });
+  service.requestContent({
+    clientReferenceId: randomUUID(),
+    blockCount: 14_400,
+    webhookUrl: `${Config.instance().webhookBaseUrl}/content-watcher/announcements`,
+  });
 });
 
 // Swagger UI

--- a/backend/openapi-specs/content-watcher-service.json
+++ b/backend/openapi-specs/content-watcher-service.json
@@ -323,25 +323,25 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "schemaIds",
-          "dsnpIds"
-        ]
+        }
       },
       "ContentSearchRequestDto": {
         "type": "object",
         "properties": {
+          "clientReferenceId": {
+            "type": "string",
+            "description": "An optional client-supplied reference ID by which it can identify the result of this search"
+          },
           "startBlock": {
             "type": "number",
             "minimum": 1,
-            "description": "The starting block number to search from",
+            "description": "The block number to search (backward) from",
             "example": 100
           },
-          "endBlock": {
+          "blockCount": {
             "type": "number",
             "minimum": 1,
-            "description": "The ending block number to search to",
+            "description": "The number of blocks to scan (backwards)",
             "example": 101
           },
           "filters": {
@@ -352,15 +352,14 @@
               }
             ]
           },
-          "id": {
-            "type": "string"
+          "webhookUrl": {
+            "type": "string",
+            "description": "A webhook URL to be notified of the results of this search"
           }
         },
         "required": [
-          "startBlock",
-          "endBlock",
-          "filters",
-          "id"
+          "blockCount",
+          "webhookUrl"
         ]
       },
       "WebhookRegistrationDto": {

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -51,7 +51,7 @@ export function add(content: AnnouncementResponse) {
 export function get(options?: ContentSearchParametersType): AnnouncementResponse[] {
   return [...contentMap.values()].filter((content) => {
     if (options) {
-      if (options.schemaIds && !options.schemaIds.includes(content.schemaId)) {
+      if (options.schemaIds && !options.schemaIds.includes(content.schemaId.toString())) {
         return false;
       }
 

--- a/backend/services/ContentWatcherService.ts
+++ b/backend/services/ContentWatcherService.ts
@@ -5,7 +5,8 @@ import * as Config from '../config/config';
 import logger from '../logger';
 import { AnnouncementType } from '../types/content-announcement';
 
-type ResetScannerDto = Components.Schemas.ResetScannerDto;
+export type ResetScannerDto = Components.Schemas.ResetScannerDto;
+export type ContentSearchRequestDto = Components.Schemas.ContentSearchRequestDto;
 
 export class ContentWatcherService {
   private static instance: ContentWatcherService;
@@ -91,6 +92,15 @@ export class ContentWatcherService {
     } catch (err) {
       logger.error(err, 'Error getting content-watcher scanner ready status');
       return false;
+    }
+  }
+
+  public async requestContent(options: ContentSearchRequestDto) {
+    try {
+      await this.client.SearchControllerV1_search(null, options);
+      logger.info(options, 'Sent content search request to content-watcher');
+    } catch (err) {
+      logger.error(err, 'Error requesting content from content-watcher');
     }
   }
 }

--- a/backend/types/api.d.ts
+++ b/backend/types/api.d.ts
@@ -12,12 +12,14 @@ declare namespace Components {
   }
   namespace Schemas {
     export interface AuthAccountResponse {
-      accessToken?: string;
-      expires?: number;
+      accessToken: string;
+      expires: number;
       referenceId?: string;
       msaId: string;
       handle?: {
-        [key: string]: any;
+        base_handle: string;
+        canonical_base: string;
+        suffix: number;
       };
     }
     export interface Broadcast {
@@ -89,7 +91,11 @@ declare namespace Components {
     }
     export interface HandlesResponse {
       publicKey: string;
-      handle: string;
+      handle: {
+        base_handle: string;
+        canonical_base: string;
+        suffix: number;
+      };
     }
     export interface LoginRequest {
       algo: 'SR25519';
@@ -133,7 +139,11 @@ declare namespace Components {
        * Timestamp of the post
        */
       timestamp: string;
-      displayHandle?: string;
+      handle?: {
+        base_handle: string;
+        canonical_base: string;
+        suffix: number;
+      };
     }
     export interface ProviderResponse {
       nodeUrl: string;
@@ -204,7 +214,11 @@ declare namespace Components {
     export interface WalletLoginResponse {
       referenceId: string;
       msaId?: string;
-      handle?: string;
+      handle?: {
+        base_handle: string;
+        canonical_base: string;
+        suffix: number;
+      };
     }
   }
 }
@@ -362,6 +376,28 @@ declare namespace Paths {
       export type $401 = Components.Responses.UnauthorizedError;
     }
   }
+  namespace GraphOperationStatus {
+    namespace Parameters {
+      export type ReferenceId = string;
+    }
+    export interface PathParameters {
+      referenceId: Parameters.ReferenceId;
+    }
+    namespace Responses {
+      export interface $200 {
+        /**
+         * ReferenceId from the request
+         */
+        referenceId: string;
+        /**
+         * status
+         */
+        status: 'pending' | 'expired' | 'failed' | 'succeeded';
+      }
+      export type $401 = Components.Responses.UnauthorizedError;
+      export interface $404 {}
+    }
+  }
   namespace GraphUnfollow {
     namespace Parameters {
       export type MsaId = string;
@@ -475,7 +511,7 @@ export interface OperationMethods {
     config?: AxiosRequestConfig
   ): OperationResponse<Paths.GetFeed.Responses.$200>;
   /**
-   * getDiscover - Get the Discovery Feed for the current user, paginated
+   * getDiscover - Get the Discovery Feed, paginated
    */
   'getDiscover'(
     parameters?: Parameters<Paths.GetDiscover.QueryParameters> | null,
@@ -514,6 +550,14 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig
   ): OperationResponse<Paths.UserFollowing.Responses.$200>;
+  /**
+   * graphOperationStatus - Get the status of a previously submitted graph operation by its referenceId
+   */
+  'graphOperationStatus'(
+    parameters: Parameters<Paths.GraphOperationStatus.PathParameters>,
+    data?: any,
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.GraphOperationStatus.Responses.$200>;
   /**
    * graphFollow - Follow a user
    */
@@ -633,7 +677,7 @@ export interface PathsDictionary {
   };
   ['/content/discover']: {
     /**
-     * getDiscover - Get the Discovery Feed for the current user, paginated
+     * getDiscover - Get the Discovery Feed, paginated
      */
     'get'(
       parameters?: Parameters<Paths.GetDiscover.QueryParameters> | null,
@@ -680,6 +724,16 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig
     ): OperationResponse<Paths.UserFollowing.Responses.$200>;
+  };
+  ['/graph/operations/{referenceId}']: {
+    /**
+     * graphOperationStatus - Get the status of a previously submitted graph operation by its referenceId
+     */
+    'get'(
+      parameters: Parameters<Paths.GraphOperationStatus.PathParameters>,
+      data?: any,
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.GraphOperationStatus.Responses.$200>;
   };
   ['/graph/{msaId}/follow']: {
     /**

--- a/backend/types/api.d.ts
+++ b/backend/types/api.d.ts
@@ -12,14 +12,12 @@ declare namespace Components {
   }
   namespace Schemas {
     export interface AuthAccountResponse {
-      accessToken: string;
-      expires: number;
+      accessToken?: string;
+      expires?: number;
       referenceId?: string;
       msaId: string;
       handle?: {
-        base_handle: string;
-        canonical_base: string;
-        suffix: number;
+        [key: string]: any;
       };
     }
     export interface Broadcast {
@@ -91,11 +89,7 @@ declare namespace Components {
     }
     export interface HandlesResponse {
       publicKey: string;
-      handle: {
-        base_handle: string;
-        canonical_base: string;
-        suffix: number;
-      };
+      handle: string;
     }
     export interface LoginRequest {
       algo: 'SR25519';
@@ -139,11 +133,7 @@ declare namespace Components {
        * Timestamp of the post
        */
       timestamp: string;
-      handle?: {
-        base_handle: string;
-        canonical_base: string;
-        suffix: number;
-      };
+      displayHandle?: string;
     }
     export interface ProviderResponse {
       nodeUrl: string;
@@ -214,11 +204,7 @@ declare namespace Components {
     export interface WalletLoginResponse {
       referenceId: string;
       msaId?: string;
-      handle?: {
-        base_handle: string;
-        canonical_base: string;
-        suffix: number;
-      };
+      handle?: string;
     }
   }
 }
@@ -376,28 +362,6 @@ declare namespace Paths {
       export type $401 = Components.Responses.UnauthorizedError;
     }
   }
-  namespace GraphOperationStatus {
-    namespace Parameters {
-      export type ReferenceId = string;
-    }
-    export interface PathParameters {
-      referenceId: Parameters.ReferenceId;
-    }
-    namespace Responses {
-      export interface $200 {
-        /**
-         * ReferenceId from the request
-         */
-        referenceId: string;
-        /**
-         * status
-         */
-        status: 'pending' | 'expired' | 'failed' | 'succeeded';
-      }
-      export type $401 = Components.Responses.UnauthorizedError;
-      export interface $404 {}
-    }
-  }
   namespace GraphUnfollow {
     namespace Parameters {
       export type MsaId = string;
@@ -511,7 +475,7 @@ export interface OperationMethods {
     config?: AxiosRequestConfig
   ): OperationResponse<Paths.GetFeed.Responses.$200>;
   /**
-   * getDiscover - Get the Discovery Feed, paginated
+   * getDiscover - Get the Discovery Feed for the current user, paginated
    */
   'getDiscover'(
     parameters?: Parameters<Paths.GetDiscover.QueryParameters> | null,
@@ -550,14 +514,6 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig
   ): OperationResponse<Paths.UserFollowing.Responses.$200>;
-  /**
-   * graphOperationStatus - Get the status of a previously submitted graph operation by its referenceId
-   */
-  'graphOperationStatus'(
-    parameters: Parameters<Paths.GraphOperationStatus.PathParameters>,
-    data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.GraphOperationStatus.Responses.$200>;
   /**
    * graphFollow - Follow a user
    */
@@ -677,7 +633,7 @@ export interface PathsDictionary {
   };
   ['/content/discover']: {
     /**
-     * getDiscover - Get the Discovery Feed, paginated
+     * getDiscover - Get the Discovery Feed for the current user, paginated
      */
     'get'(
       parameters?: Parameters<Paths.GetDiscover.QueryParameters> | null,
@@ -724,16 +680,6 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig
     ): OperationResponse<Paths.UserFollowing.Responses.$200>;
-  };
-  ['/graph/operations/{referenceId}']: {
-    /**
-     * graphOperationStatus - Get the status of a previously submitted graph operation by its referenceId
-     */
-    'get'(
-      parameters: Parameters<Paths.GraphOperationStatus.PathParameters>,
-      data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.GraphOperationStatus.Responses.$200>;
   };
   ['/graph/{msaId}/follow']: {
     /**

--- a/backend/types/content-announcement/types.gen.ts
+++ b/backend/types/content-announcement/types.gen.ts
@@ -18,7 +18,7 @@ export type AnnouncementResponse = {
   /**
    * Identifier for the schema being used or referenced
    */
-  schemaId: string;
+  schemaId: number;
   /**
    * The block number on the blockchain where this announcement was recorded
    */

--- a/backend/types/openapi-content-watcher-service.d.ts
+++ b/backend/types/openapi-content-watcher-service.d.ts
@@ -4,197 +4,188 @@ import type {
   UnknownParamsObject,
   OperationResponse,
   AxiosRequestConfig,
-} from 'openapi-client-axios'; 
+} from 'openapi-client-axios';
 
 declare namespace Components {
-    namespace Schemas {
-        export interface ChainWatchOptionsDto {
-            /**
-             * Specific schema ids to watch for
-             * example:
-             * [
-             *   1,
-             *   19
-             * ]
-             */
-            schemaIds?: number[];
-            /**
-             * Specific dsnpIds (msa_id) to watch for
-             * example:
-             * [
-             *   "10074",
-             *   "100001"
-             * ]
-             */
-            dsnpIds?: string[];
-        }
-        export interface ContentSearchRequestDto {
-            /**
-             * An optional client-supplied reference ID by which it can identify the result of this search
-             */
-            clientReferenceId?: string;
-            /**
-             * The block number to search (backward) from
-             * example:
-             * 100
-             */
-            startBlock?: number;
-            /**
-             * The number of blocks to scan (backwards)
-             * example:
-             * 101
-             */
-            blockCount: number;
-            /**
-             * The schemaIds/dsnpIds to filter by
-             */
-            filters?: {
-                /**
-                 * Specific schema ids to watch for
-                 * example:
-                 * [
-                 *   1,
-                 *   19
-                 * ]
-                 */
-                schemaIds?: number[];
-                /**
-                 * Specific dsnpIds (msa_id) to watch for
-                 * example:
-                 * [
-                 *   "10074",
-                 *   "100001"
-                 * ]
-                 */
-                dsnpIds?: string[];
-            };
-            /**
-             * A webhook URL to be notified of the results of this search
-             */
-            webhookUrl: string;
-        }
-        export interface ResetScannerDto {
-            /**
-             * The block number to reset the scanner to
-             * example:
-             * 0
-             */
-            blockNumber?: number;
-            /**
-             * Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else from latest block
-             * example:
-             * 100
-             */
-            rewindOffset?: number;
-            /**
-             * Whether to schedule the new scan immediately or wait for the next scheduled interval
-             * example:
-             * true
-             */
-            immediate?: boolean;
-        }
-        export interface WebhookRegistrationDto {
-            /**
-             * Webhook URL
-             * example:
-             * https://example.com/webhook
-             */
-            url: string;
-            /**
-             * Announcement types to send to the webhook
-             * example:
-             * [
-             *   "Broadcast",
-             *   "Reaction",
-             *   "Tombstone",
-             *   "Reply",
-             *   "Update"
-             * ]
-             */
-            announcementTypes: string[];
-        }
+  namespace Schemas {
+    export interface ChainWatchOptionsDto {
+      /**
+       * Specific schema ids to watch for
+       * example:
+       * [
+       *   1,
+       *   19
+       * ]
+       */
+      schemaIds?: number[];
+      /**
+       * Specific dsnpIds (msa_id) to watch for
+       * example:
+       * [
+       *   "10074",
+       *   "100001"
+       * ]
+       */
+      dsnpIds?: string[];
     }
+    export interface ContentSearchRequestDto {
+      /**
+       * An optional client-supplied reference ID by which it can identify the result of this search
+       */
+      clientReferenceId?: string;
+      /**
+       * The block number to search (backward) from
+       * example:
+       * 100
+       */
+      startBlock?: number;
+      /**
+       * The number of blocks to scan (backwards)
+       * example:
+       * 101
+       */
+      blockCount: number;
+      /**
+       * The schemaIds/dsnpIds to filter by
+       */
+      filters?: {
+        /**
+         * Specific schema ids to watch for
+         * example:
+         * [
+         *   1,
+         *   19
+         * ]
+         */
+        schemaIds?: number[];
+        /**
+         * Specific dsnpIds (msa_id) to watch for
+         * example:
+         * [
+         *   "10074",
+         *   "100001"
+         * ]
+         */
+        dsnpIds?: string[];
+      };
+      /**
+       * A webhook URL to be notified of the results of this search
+       */
+      webhookUrl: string;
+    }
+    export interface ResetScannerDto {
+      /**
+       * The block number to reset the scanner to
+       * example:
+       * 0
+       */
+      blockNumber?: number;
+      /**
+       * Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else from latest block
+       * example:
+       * 100
+       */
+      rewindOffset?: number;
+      /**
+       * Whether to schedule the new scan immediately or wait for the next scheduled interval
+       * example:
+       * true
+       */
+      immediate?: boolean;
+    }
+    export interface WebhookRegistrationDto {
+      /**
+       * Webhook URL
+       * example:
+       * https://example.com/webhook
+       */
+      url: string;
+      /**
+       * Announcement types to send to the webhook
+       * example:
+       * [
+       *   "Broadcast",
+       *   "Reaction",
+       *   "Tombstone",
+       *   "Reply",
+       *   "Update"
+       * ]
+       */
+      announcementTypes: string[];
+    }
+  }
 }
 declare namespace Paths {
-    namespace HealthControllerHealthz {
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+  namespace HealthControllerHealthz {
+    namespace Responses {
+      export interface $200 {}
     }
-    namespace HealthControllerLivez {
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+  }
+  namespace HealthControllerLivez {
+    namespace Responses {
+      export interface $200 {}
     }
-    namespace HealthControllerReadyz {
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+  }
+  namespace HealthControllerReadyz {
+    namespace Responses {
+      export interface $200 {}
     }
-    namespace ScanControllerV1GetWatchOptions {
-        namespace Responses {
-            export type $200 = Components.Schemas.ChainWatchOptionsDto;
-        }
+  }
+  namespace ScanControllerV1GetWatchOptions {
+    namespace Responses {
+      export type $200 = Components.Schemas.ChainWatchOptionsDto;
     }
-    namespace ScanControllerV1PauseScanner {
-        namespace Responses {
-            export interface $201 {
-            }
-        }
+  }
+  namespace ScanControllerV1PauseScanner {
+    namespace Responses {
+      export interface $201 {}
     }
-    namespace ScanControllerV1ResetScanner {
-        export type RequestBody = Components.Schemas.ResetScannerDto;
-        namespace Responses {
-            export interface $201 {
-            }
-        }
+  }
+  namespace ScanControllerV1ResetScanner {
+    export type RequestBody = Components.Schemas.ResetScannerDto;
+    namespace Responses {
+      export interface $201 {}
     }
-    namespace ScanControllerV1SetWatchOptions {
-        export type RequestBody = Components.Schemas.ChainWatchOptionsDto;
-        namespace Responses {
-            export interface $201 {
-            }
-        }
+  }
+  namespace ScanControllerV1SetWatchOptions {
+    export type RequestBody = Components.Schemas.ChainWatchOptionsDto;
+    namespace Responses {
+      export interface $201 {}
     }
-    namespace ScanControllerV1StartScanner {
-        namespace Parameters {
-            export type Immediate = boolean;
-        }
-        export interface QueryParameters {
-            immediate?: Parameters.Immediate;
-        }
-        namespace Responses {
-            export interface $201 {
-            }
-        }
+  }
+  namespace ScanControllerV1StartScanner {
+    namespace Parameters {
+      export type Immediate = boolean;
     }
-    namespace SearchControllerV1Search {
-        export type RequestBody = Components.Schemas.ContentSearchRequestDto;
-        namespace Responses {
-            export type $200 = string;
-        }
+    export interface QueryParameters {
+      immediate?: Parameters.Immediate;
     }
-    namespace WebhookControllerV1ClearAllWebHooks {
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+    namespace Responses {
+      export interface $201 {}
     }
-    namespace WebhookControllerV1GetRegisteredWebhooks {
-        namespace Responses {
-            export type $200 = Components.Schemas.WebhookRegistrationDto[];
-        }
+  }
+  namespace SearchControllerV1Search {
+    export type RequestBody = Components.Schemas.ContentSearchRequestDto;
+    namespace Responses {
+      export type $200 = string;
     }
-    namespace WebhookControllerV1RegisterWebhook {
-        export type RequestBody = Components.Schemas.WebhookRegistrationDto;
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+  }
+  namespace WebhookControllerV1ClearAllWebHooks {
+    namespace Responses {
+      export interface $200 {}
     }
+  }
+  namespace WebhookControllerV1GetRegisteredWebhooks {
+    namespace Responses {
+      export type $200 = Components.Schemas.WebhookRegistrationDto[];
+    }
+  }
+  namespace WebhookControllerV1RegisterWebhook {
+    export type RequestBody = Components.Schemas.WebhookRegistrationDto;
+    namespace Responses {
+      export interface $200 {}
+    }
+  }
 }
 
 export interface OperationMethods {
@@ -204,96 +195,96 @@ export interface OperationMethods {
   'ScanControllerV1_resetScanner'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.ScanControllerV1ResetScanner.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>;
   /**
    * ScanControllerV1_getWatchOptions - Get the current watch options for the blockchain content event scanner
    */
   'ScanControllerV1_getWatchOptions'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>;
   /**
    * ScanControllerV1_setWatchOptions - Set watch options to filter the blockchain content scanner by schemas or MSA IDs
    */
   'ScanControllerV1_setWatchOptions'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.ScanControllerV1SetWatchOptions.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>;
   /**
    * ScanControllerV1_pauseScanner - Pause the blockchain scanner
    */
   'ScanControllerV1_pauseScanner'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>;
   /**
    * ScanControllerV1_startScanner - Resume the blockchain content event scanner
    */
   'ScanControllerV1_startScanner'(
     parameters?: Parameters<Paths.ScanControllerV1StartScanner.QueryParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>;
   /**
    * SearchControllerV1_search - Search for DSNP content by id, start/end block, and filters
    */
   'SearchControllerV1_search'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.SearchControllerV1Search.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>;
   /**
    * WebhookControllerV1_getRegisteredWebhooks - Get the list of currently registered webhooks
    */
   'WebhookControllerV1_getRegisteredWebhooks'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>;
   /**
    * WebhookControllerV1_registerWebhook - Register a webhook to be called when new content is encountered on the chain
    */
   'WebhookControllerV1_registerWebhook'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.WebhookControllerV1RegisterWebhook.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>;
   /**
    * WebhookControllerV1_clearAllWebHooks - Clear all previously registered webhooks
    */
   'WebhookControllerV1_clearAllWebHooks'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>;
   /**
    * HealthController_healthz - Check the health status of the service
    */
   'HealthController_healthz'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>;
   /**
    * HealthController_livez - Check the live status of the service
    */
   'HealthController_livez'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>;
   /**
    * HealthController_readyz - Check the ready status of the service
    */
   'HealthController_readyz'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>;
 }
 
 export interface PathsDictionary {
@@ -304,9 +295,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.ScanControllerV1ResetScanner.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>;
+  };
   ['/v1/scanner/options']: {
     /**
      * ScanControllerV1_getWatchOptions - Get the current watch options for the blockchain content event scanner
@@ -314,17 +305,17 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>;
     /**
      * ScanControllerV1_setWatchOptions - Set watch options to filter the blockchain content scanner by schemas or MSA IDs
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.ScanControllerV1SetWatchOptions.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>;
+  };
   ['/v1/scanner/pause']: {
     /**
      * ScanControllerV1_pauseScanner - Pause the blockchain scanner
@@ -332,9 +323,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>;
+  };
   ['/v1/scanner/start']: {
     /**
      * ScanControllerV1_startScanner - Resume the blockchain content event scanner
@@ -342,9 +333,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<Paths.ScanControllerV1StartScanner.QueryParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>;
+  };
   ['/v1/search']: {
     /**
      * SearchControllerV1_search - Search for DSNP content by id, start/end block, and filters
@@ -352,9 +343,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.SearchControllerV1Search.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>;
+  };
   ['/v1/webhooks']: {
     /**
      * WebhookControllerV1_registerWebhook - Register a webhook to be called when new content is encountered on the chain
@@ -362,25 +353,25 @@ export interface PathsDictionary {
     'put'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.WebhookControllerV1RegisterWebhook.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>;
     /**
      * WebhookControllerV1_clearAllWebHooks - Clear all previously registered webhooks
      */
     'delete'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>;
     /**
      * WebhookControllerV1_getRegisteredWebhooks - Get the list of currently registered webhooks
      */
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>;
+  };
   ['/healthz']: {
     /**
      * HealthController_healthz - Check the health status of the service
@@ -388,9 +379,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>;
+  };
   ['/livez']: {
     /**
      * HealthController_livez - Check the live status of the service
@@ -398,9 +389,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>;
+  };
   ['/readyz']: {
     /**
      * HealthController_readyz - Check the ready status of the service
@@ -408,9 +399,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>
-  }
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>;
+  };
 }
 
-export type Client = OpenAPIClient<OperationMethods, PathsDictionary>
+export type Client = OpenAPIClient<OperationMethods, PathsDictionary>;

--- a/backend/types/openapi-content-watcher-service.d.ts
+++ b/backend/types/openapi-content-watcher-service.d.ts
@@ -4,181 +4,197 @@ import type {
   UnknownParamsObject,
   OperationResponse,
   AxiosRequestConfig,
-} from 'openapi-client-axios';
+} from 'openapi-client-axios'; 
 
 declare namespace Components {
-  namespace Schemas {
-    export interface ChainWatchOptionsDto {
-      /**
-       * Specific schema ids to watch for
-       * example:
-       * [
-       *   1,
-       *   19
-       * ]
-       */
-      schemaIds: number[];
-      /**
-       * Specific dsnpIds (msa_id) to watch for
-       * example:
-       * [
-       *   "10074",
-       *   "100001"
-       * ]
-       */
-      dsnpIds: string[];
+    namespace Schemas {
+        export interface ChainWatchOptionsDto {
+            /**
+             * Specific schema ids to watch for
+             * example:
+             * [
+             *   1,
+             *   19
+             * ]
+             */
+            schemaIds?: number[];
+            /**
+             * Specific dsnpIds (msa_id) to watch for
+             * example:
+             * [
+             *   "10074",
+             *   "100001"
+             * ]
+             */
+            dsnpIds?: string[];
+        }
+        export interface ContentSearchRequestDto {
+            /**
+             * An optional client-supplied reference ID by which it can identify the result of this search
+             */
+            clientReferenceId?: string;
+            /**
+             * The block number to search (backward) from
+             * example:
+             * 100
+             */
+            startBlock?: number;
+            /**
+             * The number of blocks to scan (backwards)
+             * example:
+             * 101
+             */
+            blockCount: number;
+            /**
+             * The schemaIds/dsnpIds to filter by
+             */
+            filters?: {
+                /**
+                 * Specific schema ids to watch for
+                 * example:
+                 * [
+                 *   1,
+                 *   19
+                 * ]
+                 */
+                schemaIds?: number[];
+                /**
+                 * Specific dsnpIds (msa_id) to watch for
+                 * example:
+                 * [
+                 *   "10074",
+                 *   "100001"
+                 * ]
+                 */
+                dsnpIds?: string[];
+            };
+            /**
+             * A webhook URL to be notified of the results of this search
+             */
+            webhookUrl: string;
+        }
+        export interface ResetScannerDto {
+            /**
+             * The block number to reset the scanner to
+             * example:
+             * 0
+             */
+            blockNumber?: number;
+            /**
+             * Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else from latest block
+             * example:
+             * 100
+             */
+            rewindOffset?: number;
+            /**
+             * Whether to schedule the new scan immediately or wait for the next scheduled interval
+             * example:
+             * true
+             */
+            immediate?: boolean;
+        }
+        export interface WebhookRegistrationDto {
+            /**
+             * Webhook URL
+             * example:
+             * https://example.com/webhook
+             */
+            url: string;
+            /**
+             * Announcement types to send to the webhook
+             * example:
+             * [
+             *   "Broadcast",
+             *   "Reaction",
+             *   "Tombstone",
+             *   "Reply",
+             *   "Update"
+             * ]
+             */
+            announcementTypes: string[];
+        }
     }
-    export interface ContentSearchRequestDto {
-      /**
-       * The starting block number to search from
-       * example:
-       * 100
-       */
-      startBlock: number;
-      /**
-       * The ending block number to search to
-       * example:
-       * 101
-       */
-      endBlock: number;
-      /**
-       * The schemaIds/dsnpIds to filter by
-       */
-      filters: {
-        /**
-         * Specific schema ids to watch for
-         * example:
-         * [
-         *   1,
-         *   19
-         * ]
-         */
-        schemaIds: number[];
-        /**
-         * Specific dsnpIds (msa_id) to watch for
-         * example:
-         * [
-         *   "10074",
-         *   "100001"
-         * ]
-         */
-        dsnpIds: string[];
-      };
-      id: string;
-    }
-    export interface ResetScannerDto {
-      /**
-       * The block number to reset the scanner to
-       * example:
-       * 0
-       */
-      blockNumber?: number;
-      /**
-       * Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else from latest block
-       * example:
-       * 100
-       */
-      rewindOffset?: number;
-      /**
-       * Whether to schedule the new scan immediately or wait for the next scheduled interval
-       * example:
-       * true
-       */
-      immediate?: boolean;
-    }
-    export interface WebhookRegistrationDto {
-      /**
-       * Webhook URL
-       * example:
-       * https://example.com/webhook
-       */
-      url: string;
-      /**
-       * Announcement types to send to the webhook
-       * example:
-       * [
-       *   "Broadcast",
-       *   "Reaction",
-       *   "Tombstone",
-       *   "Reply",
-       *   "Update"
-       * ]
-       */
-      announcementTypes: string[];
-    }
-  }
 }
 declare namespace Paths {
-  namespace HealthControllerHealthz {
-    namespace Responses {
-      export interface $200 {}
+    namespace HealthControllerHealthz {
+        namespace Responses {
+            export interface $200 {
+            }
+        }
     }
-  }
-  namespace HealthControllerLivez {
-    namespace Responses {
-      export interface $200 {}
+    namespace HealthControllerLivez {
+        namespace Responses {
+            export interface $200 {
+            }
+        }
     }
-  }
-  namespace HealthControllerReadyz {
-    namespace Responses {
-      export interface $200 {}
+    namespace HealthControllerReadyz {
+        namespace Responses {
+            export interface $200 {
+            }
+        }
     }
-  }
-  namespace ScanControllerV1GetWatchOptions {
-    namespace Responses {
-      export type $200 = Components.Schemas.ChainWatchOptionsDto;
+    namespace ScanControllerV1GetWatchOptions {
+        namespace Responses {
+            export type $200 = Components.Schemas.ChainWatchOptionsDto;
+        }
     }
-  }
-  namespace ScanControllerV1PauseScanner {
-    namespace Responses {
-      export interface $201 {}
+    namespace ScanControllerV1PauseScanner {
+        namespace Responses {
+            export interface $201 {
+            }
+        }
     }
-  }
-  namespace ScanControllerV1ResetScanner {
-    export type RequestBody = Components.Schemas.ResetScannerDto;
-    namespace Responses {
-      export interface $201 {}
+    namespace ScanControllerV1ResetScanner {
+        export type RequestBody = Components.Schemas.ResetScannerDto;
+        namespace Responses {
+            export interface $201 {
+            }
+        }
     }
-  }
-  namespace ScanControllerV1SetWatchOptions {
-    export type RequestBody = Components.Schemas.ChainWatchOptionsDto;
-    namespace Responses {
-      export interface $201 {}
+    namespace ScanControllerV1SetWatchOptions {
+        export type RequestBody = Components.Schemas.ChainWatchOptionsDto;
+        namespace Responses {
+            export interface $201 {
+            }
+        }
     }
-  }
-  namespace ScanControllerV1StartScanner {
-    namespace Parameters {
-      export type Immediate = boolean;
+    namespace ScanControllerV1StartScanner {
+        namespace Parameters {
+            export type Immediate = boolean;
+        }
+        export interface QueryParameters {
+            immediate?: Parameters.Immediate;
+        }
+        namespace Responses {
+            export interface $201 {
+            }
+        }
     }
-    export interface QueryParameters {
-      immediate?: Parameters.Immediate;
+    namespace SearchControllerV1Search {
+        export type RequestBody = Components.Schemas.ContentSearchRequestDto;
+        namespace Responses {
+            export type $200 = string;
+        }
     }
-    namespace Responses {
-      export interface $201 {}
+    namespace WebhookControllerV1ClearAllWebHooks {
+        namespace Responses {
+            export interface $200 {
+            }
+        }
     }
-  }
-  namespace SearchControllerV1Search {
-    export type RequestBody = Components.Schemas.ContentSearchRequestDto;
-    namespace Responses {
-      export type $200 = string;
+    namespace WebhookControllerV1GetRegisteredWebhooks {
+        namespace Responses {
+            export type $200 = Components.Schemas.WebhookRegistrationDto[];
+        }
     }
-  }
-  namespace WebhookControllerV1ClearAllWebHooks {
-    namespace Responses {
-      export interface $200 {}
+    namespace WebhookControllerV1RegisterWebhook {
+        export type RequestBody = Components.Schemas.WebhookRegistrationDto;
+        namespace Responses {
+            export interface $200 {
+            }
+        }
     }
-  }
-  namespace WebhookControllerV1GetRegisteredWebhooks {
-    namespace Responses {
-      export type $200 = Components.Schemas.WebhookRegistrationDto[];
-    }
-  }
-  namespace WebhookControllerV1RegisterWebhook {
-    export type RequestBody = Components.Schemas.WebhookRegistrationDto;
-    namespace Responses {
-      export interface $200 {}
-    }
-  }
 }
 
 export interface OperationMethods {
@@ -188,96 +204,96 @@ export interface OperationMethods {
   'ScanControllerV1_resetScanner'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.ScanControllerV1ResetScanner.RequestBody,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>
   /**
    * ScanControllerV1_getWatchOptions - Get the current watch options for the blockchain content event scanner
    */
   'ScanControllerV1_getWatchOptions'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>
   /**
    * ScanControllerV1_setWatchOptions - Set watch options to filter the blockchain content scanner by schemas or MSA IDs
    */
   'ScanControllerV1_setWatchOptions'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.ScanControllerV1SetWatchOptions.RequestBody,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>
   /**
    * ScanControllerV1_pauseScanner - Pause the blockchain scanner
    */
   'ScanControllerV1_pauseScanner'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>
   /**
    * ScanControllerV1_startScanner - Resume the blockchain content event scanner
    */
   'ScanControllerV1_startScanner'(
     parameters?: Parameters<Paths.ScanControllerV1StartScanner.QueryParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>
   /**
    * SearchControllerV1_search - Search for DSNP content by id, start/end block, and filters
    */
   'SearchControllerV1_search'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.SearchControllerV1Search.RequestBody,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>
   /**
    * WebhookControllerV1_getRegisteredWebhooks - Get the list of currently registered webhooks
    */
   'WebhookControllerV1_getRegisteredWebhooks'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>
   /**
    * WebhookControllerV1_registerWebhook - Register a webhook to be called when new content is encountered on the chain
    */
   'WebhookControllerV1_registerWebhook'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.WebhookControllerV1RegisterWebhook.RequestBody,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>
   /**
    * WebhookControllerV1_clearAllWebHooks - Clear all previously registered webhooks
    */
   'WebhookControllerV1_clearAllWebHooks'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>
   /**
    * HealthController_healthz - Check the health status of the service
    */
   'HealthController_healthz'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>
   /**
    * HealthController_livez - Check the live status of the service
    */
   'HealthController_livez'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>
   /**
    * HealthController_readyz - Check the ready status of the service
    */
   'HealthController_readyz'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig
-  ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>;
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>
 }
 
 export interface PathsDictionary {
@@ -288,9 +304,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.ScanControllerV1ResetScanner.RequestBody,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.ScanControllerV1ResetScanner.Responses.$201>
+  }
   ['/v1/scanner/options']: {
     /**
      * ScanControllerV1_getWatchOptions - Get the current watch options for the blockchain content event scanner
@@ -298,17 +314,17 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>;
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.ScanControllerV1GetWatchOptions.Responses.$200>
     /**
      * ScanControllerV1_setWatchOptions - Set watch options to filter the blockchain content scanner by schemas or MSA IDs
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.ScanControllerV1SetWatchOptions.RequestBody,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.ScanControllerV1SetWatchOptions.Responses.$201>
+  }
   ['/v1/scanner/pause']: {
     /**
      * ScanControllerV1_pauseScanner - Pause the blockchain scanner
@@ -316,9 +332,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.ScanControllerV1PauseScanner.Responses.$201>
+  }
   ['/v1/scanner/start']: {
     /**
      * ScanControllerV1_startScanner - Resume the blockchain content event scanner
@@ -326,9 +342,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<Paths.ScanControllerV1StartScanner.QueryParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.ScanControllerV1StartScanner.Responses.$201>
+  }
   ['/v1/search']: {
     /**
      * SearchControllerV1_search - Search for DSNP content by id, start/end block, and filters
@@ -336,9 +352,9 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.SearchControllerV1Search.RequestBody,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.SearchControllerV1Search.Responses.$200>
+  }
   ['/v1/webhooks']: {
     /**
      * WebhookControllerV1_registerWebhook - Register a webhook to be called when new content is encountered on the chain
@@ -346,25 +362,25 @@ export interface PathsDictionary {
     'put'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.WebhookControllerV1RegisterWebhook.RequestBody,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>;
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.WebhookControllerV1RegisterWebhook.Responses.$200>
     /**
      * WebhookControllerV1_clearAllWebHooks - Clear all previously registered webhooks
      */
     'delete'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>;
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.WebhookControllerV1ClearAllWebHooks.Responses.$200>
     /**
      * WebhookControllerV1_getRegisteredWebhooks - Get the list of currently registered webhooks
      */
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.WebhookControllerV1GetRegisteredWebhooks.Responses.$200>
+  }
   ['/healthz']: {
     /**
      * HealthController_healthz - Check the health status of the service
@@ -372,9 +388,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.HealthControllerHealthz.Responses.$200>
+  }
   ['/livez']: {
     /**
      * HealthController_livez - Check the live status of the service
@@ -382,9 +398,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.HealthControllerLivez.Responses.$200>
+  }
   ['/readyz']: {
     /**
      * HealthController_readyz - Check the ready status of the service
@@ -392,9 +408,9 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig
-    ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>;
-  };
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.HealthControllerReadyz.Responses.$200>
+  }
 }
 
-export type Client = OpenAPIClient<OperationMethods, PathsDictionary>;
+export type Client = OpenAPIClient<OperationMethods, PathsDictionary>


### PR DESCRIPTION
# Purpose
This PR changes from resetting the `content-watcher` scan at startup to requesting a targeted historical content search. It also incorporates updated generated types from content-watcher OpenAPI docs.