### PR TITLE
feat: first pass at adding persistence to announced content

### DIFF
--- a/backend/controllers/WebhookController.ts
+++ b/backend/controllers/WebhookController.ts
@@ -4,7 +4,7 @@ import { HttpStatusCode } from 'axios';
 import { AccountServiceWebhook } from '../services/AccountWebhookService';
 import { HttpError } from '../types/HttpError';
 import logger from '../logger';
-import * as ContentRepository from '../repositories/ContentRepository';
+import { ContentRepository } from '../repositories/ContentRepository';
 import { GraphWebhookService } from '../services/GraphWebhookService';
 
 export class WebhookController extends BaseController {

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /app
 EXPOSE 3000
 
 VOLUME [ "/app" ]
+VOLUME [ "/app/db" ]
 
 ENTRYPOINT [ "npm", "run", "container-run:dev" ]

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -7,4 +7,6 @@ EXPOSE 3000
 VOLUME [ "/app" ]
 VOLUME [ "/app/db" ]
 
+RUN mkdir /app/db
+
 ENTRYPOINT [ "npm", "run", "container-run:dev" ]

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -22,6 +22,7 @@ import { WebhookController } from './controllers/WebhookController';
 import { ContentWatcherService } from './services/ContentWatcherService';
 import { AnnouncementType } from './types/content-announcement';
 import { randomUUID } from 'crypto';
+import { ContentRepository } from './repositories/ContentRepository';
 
 // Support BigInt JSON
 (BigInt.prototype as any).toJSON = function () {
@@ -29,6 +30,7 @@ import { randomUUID } from 'crypto';
 };
 
 Config.init(process.env);
+ContentRepository.init();
 
 const httpLogOptions: Options = {
   logger,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "@polkadot/api": "^10.9.1",
         "@polkadot/util": "^12.6.2",
         "avro-js": "^1.11.3",
+        "better-sqlite3": "^11.1.2",
         "busboy": "^1.6.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -39,6 +40,7 @@
       "devDependencies": {
         "@eslint/js": "^8.57.0",
         "@hey-api/openapi-ts": "^0.45.1",
+        "@types/better-sqlite3": "^7.6.11",
         "@types/busboy": "^1.5.3",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -3348,6 +3350,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.11",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.11.tgz",
+      "integrity": "sha512-i8KcD3PgGtGBLl3+mMYA8PdKkButvPyARxA7IQAd6qeslht13qxb1zzO8dRCtE7U3IoJS782zDBAeoKiM695kg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bn.js": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
@@ -4384,6 +4395,16 @@
       "resolved": "https://registry.npmjs.org/bath-es5/-/bath-es5-3.0.3.tgz",
       "integrity": "sha512-PdCioDToH3t84lP40kUFCKWCOCH389Dl1kbC8FGoqOwamxsmqxxnJSXdkTOsPoNHXjem4+sJ+bbNoQm5zeCqxg=="
     },
+    "node_modules/better-sqlite3": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.1.2.tgz",
+      "integrity": "sha512-gujtFwavWU4MSPT+h9B+4pkvZdyOUkH54zgLdIrMmmmd4ZqiBIrRNBzNzYVFO417xo882uP5HBu4GjOfaSrIQw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4394,6 +4415,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -5102,6 +5131,20 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -5112,6 +5155,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5215,6 +5266,14 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -5299,6 +5358,29 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -5817,6 +5899,14 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -6001,6 +6091,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -6177,6 +6272,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -6391,6 +6491,11 @@
       "bin": {
         "giget": "dist/cli.mjs"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "10.3.15",
@@ -6777,6 +6882,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/int53": {
       "version": "1.0.0",
@@ -7563,6 +7673,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7627,6 +7748,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mlly": {
       "version": "1.7.0",
@@ -7740,6 +7866,11 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7771,6 +7902,28 @@
       },
       "engines": {
         "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
+      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -8635,6 +8788,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8818,6 +8996,28 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rc9": {
@@ -9373,6 +9573,49 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -9845,6 +10088,83 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -10048,6 +10368,17 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,6 +49,7 @@
     "@polkadot/api": "^10.9.1",
     "@polkadot/util": "^12.6.2",
     "avro-js": "^1.11.3",
+    "better-sqlite3": "^11.1.2",
     "busboy": "^1.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
@@ -69,6 +70,7 @@
   "devDependencies": {
     "@eslint/js": "^8.57.0",
     "@hey-api/openapi-ts": "^0.45.1",
+    "@types/better-sqlite3": "^7.6.11",
     "@types/busboy": "^1.5.3",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -117,7 +117,6 @@ export class ContentRepository {
       case AnnouncementType.Broadcast: {
         const key = getKey(content);
         logger.debug({ key, content }, 'Storing broadcast content');
-        // ContentRepository.contentMap.set(key, content);
         const stmt = ContentRepository.db.prepare(
           'INSERT OR REPLACE INTO "announcements"("key", "announcement") VALUES (:key, json(:content))'
         );
@@ -132,7 +131,6 @@ export class ContentRepository {
         const key = getKey(content as AnnouncementResponse);
         const relatedKey = getRelatedHash(content);
         logger.debug({ key, content, relatedKey }, 'Storing response content');
-        // ContentRepository.contentResponseMap.set(key, content as RelatedAnnouncementResponse);
         const stmt = ContentRepository.db.prepare(
           'INSERT OR REPLACE INTO "announcements"("key", "relatedKey", "announcement") VALUES (:key, :relatedKey, json(:content))'
         );

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -60,7 +60,7 @@ function getContentHash(contentAnnouncement: AnnouncementResponse) {
 }
 
 function getContentHashFromURI(dsnpUri: string): string | null {
-  return /^dsnp:\/\/[\d]+\/([^\/]*)(?:\/)?/i.exec(dsnpUri)?.[1] ?? null;
+  return /^dsnp:\/\/[\d]+\/([^/]*)(?:\/)?/i.exec(dsnpUri)?.[1] ?? null;
 }
 
 function getKey(contentAnnouncement: AnnouncementResponse) {

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -14,14 +14,7 @@
  */
 
 import { createHash } from 'crypto';
-import {
-  type AnnouncementResponse,
-  AnnouncementType,
-  ReactionAnnouncement,
-  ReplyAnnouncement,
-  TombstoneAnnouncement,
-  UpdateAnnouncement,
-} from '../types/content-announcement';
+import { type AnnouncementResponse, AnnouncementType } from '../types/content-announcement';
 import '../types/content-announcement/type.augment';
 import {
   isBroadcast,
@@ -33,6 +26,7 @@ import {
 } from '../types/content-announcement/type.augment';
 import logger from '../logger';
 import Database from 'better-sqlite3';
+import { RelatedAnnouncementResponse } from '../types/types';
 
 export type ContentSearchParametersType = {
   msaIds?: string[];
@@ -42,10 +36,6 @@ export type ContentSearchParametersType = {
   blockTo?: number;
   contentHash?: string;
   relatedContentHash?: string;
-};
-
-type RelatedAnnouncementResponse = AnnouncementResponse & {
-  announcement: ReplyAnnouncement | ReactionAnnouncement | TombstoneAnnouncement | UpdateAnnouncement;
 };
 
 function getContentHash(contentAnnouncement: AnnouncementResponse) {

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -2,19 +2,28 @@
  *
  * Dummy service for caching content; replace with a persistence/cache layer of your choice.
  * This one is horribly inefficient and does not scale!
+ *
+ * Notes about this bare-bones content repository:
+ *
+ * - Primary announcements are stored by their `contentHash`. A "real" implementation
+ *   would likely have a database backend so that content announcements could be easily queried
+ *   by various criteria (MSA, timestamp/block range, schema/announcement type, etc)
+ *
+ * - Secondary announcements (Replies, Reactions, Tombstones) are indexed by the content hash
+ *   of the parent announcement
  */
 
 import { createHash } from 'crypto';
 import {
   type AnnouncementResponse,
   AnnouncementType,
-  BroadcastAnnouncement,
   ReactionAnnouncement,
   ReplyAnnouncement,
 } from '../types/content-announcement';
 import '../types/content-announcement/type.augment';
 import { isBroadcast, isProfile, isReply, isTombstone, isUpdate } from '../types/content-announcement/type.augment';
 import logger from '../logger';
+import Database from 'better-sqlite3';
 
 export type ContentSearchParametersType = {
   msaIds?: string[];
@@ -26,10 +35,6 @@ export type ContentSearchParametersType = {
 };
 
 type ResponseAnnouncementResponse = AnnouncementResponse & { announcement: ReplyAnnouncement | ReactionAnnouncement };
-
-// TODO: more tightly bind the announcement types. Reactions and replies only in contentResponseMap.
-const contentMap = new Map<string, AnnouncementResponse>();
-const contentResponseMap = new Map<string, ResponseAnnouncementResponse>();
 
 function getContentHash(contentAnnouncement: AnnouncementResponse) {
   const { announcement } = contentAnnouncement;
@@ -52,69 +57,117 @@ function getKey(contentAnnouncement: AnnouncementResponse) {
   return `${blockNumber}:${fromId}:${hash}`;
 }
 
-function getResponseKey(
-  contentAnnouncement: ResponseAnnouncementResponse
-): string {
+function getResponseKey(contentAnnouncement: ResponseAnnouncementResponse): string {
   const responseInReplyTo = contentAnnouncement.announcement.inReplyTo;
   const parentContentHash = responseInReplyTo.split('/').pop();
   if (!parentContentHash) throw new Error('Invalid URI');
   return parentContentHash;
 }
 
-export function add(content: AnnouncementResponse) {
-  switch (content.announcement.announcementType) {
-    case AnnouncementType.Broadcast: {
-      const key = getKey(content);
-      contentMap.set(key, content);
-      logger.debug({ key, content }, 'Storing broadcast content');
-      break;
+export class ContentRepository {
+  private static db: any;
+  // TODO: more tightly bind the announcement types. Reactions and replies only in contentResponseMap.
+  private static contentMap = new Map<string, AnnouncementResponse>();
+  private static contentResponseMap = new Map<string, ResponseAnnouncementResponse>();
+
+  static init() {
+    try {
+      ContentRepository.db = new Database('./db/contentDb.sqlite', {
+        fileMustExist: true,
+        verbose: (msg) => logger.info(msg),
+      });
+    } catch (err) {
+      logger.info('Creating content DB...');
+      ContentRepository.db = new Database('./db/contentDb.sqlite', {
+        fileMustExist: false,
+        verbose: (msg) => logger.info(msg),
+      });
+      ContentRepository.db.exec(
+        'CREATE TABLE IF NOT EXISTS "announcements"("id" INTEGER PRIMARY KEY ASC, "key" TEXT UNIQUE, "announcement" BLOB, "content" BLOB)'
+      );
     }
-    case AnnouncementType.Reply:
-    case AnnouncementType.Reaction: {
-      const key = getResponseKey(content as ResponseAnnouncementResponse);
-      contentResponseMap.set(key, content as ResponseAnnouncementResponse);
-      logger.debug({ key, content }, 'Storing response content');
-      break;
-    }
-    default: {
-      const key = getKey(content);
-      contentMap.set(key, content);
-      logger.debug({ key, content }, 'Storing broadcast content');
-      break;
+
+    logger.info('Connected to content DB');
+  }
+
+  public static add(content: AnnouncementResponse) {
+    switch (content.announcement.announcementType) {
+      case AnnouncementType.Broadcast: {
+        const key = getKey(content);
+        logger.debug({ key, content }, 'Storing broadcast content');
+        ContentRepository.contentMap.set(key, content);
+        const stmt = ContentRepository.db.prepare('INSERT INTO "announcements"("announcement") VALUES (json(?))');
+        const result = stmt.run([JSON.stringify(content)]);
+        logger.debug(result, 'Stored broadcast content in DB');
+        break;
+      }
+      case AnnouncementType.Reply:
+      case AnnouncementType.Reaction: {
+        const key = getResponseKey(content as ResponseAnnouncementResponse);
+        logger.debug({ key, content }, 'Storing response content');
+        ContentRepository.contentResponseMap.set(key, content as ResponseAnnouncementResponse);
+        const stmt = ContentRepository.db.prepare('INSERT INTO "announcements"("announcement") VALUES (json(?))');
+        const result = stmt.run([JSON.stringify(content)]);
+        logger.debug(result, 'Stored response content in DB');
+        break;
+      }
+      default: {
+        const key = getKey(content);
+        logger.debug(
+          { key, content, announcementType: content.announcement.announcementType.toString() },
+          'Storing content for other announcement'
+        );
+        ContentRepository.contentMap.set(key, content);
+        const stmt = ContentRepository.db.prepare('INSERT INTO "announcements"("announcement") VALUES (json(?))');
+        const result = stmt.run([JSON.stringify(content)]);
+        logger.debug(result, 'Stored other content in DB');
+        break;
+      }
     }
   }
-}
 
-export function get(options?: ContentSearchParametersType): AnnouncementResponse[] {
-  return [...contentMap.values()].filter((content) => {
+  public static get(options?: ContentSearchParametersType): AnnouncementResponse[] {
+    let sql = 'SELECT json("announcement") as "announcement_json" FROM "announcements" ';
+    const conditionals: string[] = [];
     if (options) {
-      if (options.schemaIds && !options.schemaIds.includes(content.schemaId.toString())) {
-        return false;
+      if (options.schemaIds) {
+        conditionals.push(`"announcement_json"->>'$.schemaId' IN (SELECT value from json_each(:schemaIds))`);
       }
 
-      if (options.announcementTypes && !options.announcementTypes.includes(content.announcement.announcementType)) {
-        return false;
+      if (options.announcementTypes) {
+        conditionals.push(
+          `"announcement_json"->>'$.announcement.announcementType' IN (SELECT value from json_each(:announcementTypes))`
+        );
       }
 
       if (options.blockFrom !== undefined) {
-        if (content.blockNumber < options.blockFrom) {
-          return false;
-        }
-
-        if (options.blockTo && content.blockNumber > options.blockTo) {
-          return false;
-        }
+        conditionals.push(`"announcement_json"->>'$.blockNumber' >= :blockFrom`);
       }
 
-      if (options.msaIds && options.msaIds.length > 0 && !options.msaIds.includes(content.announcement.fromId)) {
-        return false;
+      if (options.blockTo !== undefined) {
+        conditionals.push(`"announcement_json"->>'$.blockNumber' <= :blockTo`);
       }
 
-      if (options?.contentHash && options.contentHash !== getContentHash(content)) {
-        return false;
+      if (options.msaIds && options.msaIds.length > 0) {
+        conditionals.push(`"announcement_json"->>'$.announcement.fromId IN  (SELECT value from json_each(:msaIds))`);
       }
 
-      return true;
+      if (options.contentHash) {
+        conditionals.push(`"announcement_json"->>'$.announcement.contentHash' = :contentHash`);
+      }
     }
-  });
+
+    sql += `WHERE ${conditionals.join(' AND ')}`;
+    logger.debug({ sql }, 'Executing query to retrieve announcements');
+    const stmt = ContentRepository.db.prepare(sql);
+    const rows: { announcement_json: string }[] = stmt.all({
+      ...options,
+      schemaIds: JSON.stringify(options?.schemaIds),
+      announcementTypes: JSON.stringify(options?.announcementTypes),
+      msaIds: JSON.stringify(options?.msaIds),
+    });
+    const response = rows.map(({ announcement_json }) => JSON.parse(announcement_json) as AnnouncementResponse);
+    logger.debug({ numRows: response.length, response }, 'Retrieved content from DB');
+    return response;
+  }
 }

--- a/backend/services/feed.ts
+++ b/backend/services/feed.ts
@@ -1,6 +1,6 @@
 import type * as T from '../types/openapi.js';
 import axios from 'axios';
-import * as ContentRepository from '../repositories/ContentRepository';
+import { ContentRepository } from '../repositories/ContentRepository';
 import {
   AnnouncementResponse,
   AnnouncementType,

--- a/backend/services/feed.ts
+++ b/backend/services/feed.ts
@@ -9,95 +9,34 @@ import {
 } from '../types/content-announcement';
 import logger from '../logger.js';
 import { translateContentUrl } from '../utils/url-transation.js';
-import { Components } from '../types/api';
+import { isReply } from '../types/content-announcement/type.augment.js';
 
 export type Post = T.Components.Schemas.BroadcastExtended;
+export type Reply = T.Components.Schemas.ReplyExtended;
 interface CachedPosts {
   [blockNumber: number]: [number, Post][];
-}
-interface CachedReplies {
-  [blockNumber: number]: [number, any][];
 }
 
 type BlockRange = { from: number; to: number };
 
-async function getPostsWithRepliesForBlockRange({ from, to }: BlockRange): Promise<[number, Post][]> {
-  const postMessages = ContentRepository.get({
+async function getPostsForBlockRange({ from, to }: BlockRange): Promise<[number, Post][]> {
+  const messages = ContentRepository.get({
     blockFrom: from,
     blockTo: to,
     announcementTypes: [AnnouncementType.Broadcast],
   });
 
-  // const replyMessages = ContentRepository.get({
-  //   blockFrom: from,
-  //   blockTo: to,
-  //   announcementTypes: [AnnouncementType.Reply],
-  // });
-
-  // const replies: [number, any][] = [];
-  // // Fetch the parquet files
-  // for (const msg of replyMessages) {
-  //   const reply = await getReplyContent(msg);
-  //   if (reply) {
-  //     replies.push(reply);
-  //   }
-  // }
-
-  const postsWithReplies: [number, Post][] = [];
+  const posts: [number, Post][] = [];
   // Fetch the parquet files
-  for (const msg of postMessages) {
+  for (const msg of messages) {
     const post = await getPostContent(msg);
     if (post) {
-      postsWithReplies.push(post);
+      posts.push(post);
     }
   }
 
   // Return the posts
-  return postsWithReplies;
-}
-
-// async function getRepliesForBlockRange({ from, to }: BlockRange): Promise<[number, any][]> {
-//   const messages = ContentRepository.get({
-//     blockFrom: from,
-//     blockTo: to,
-//     announcementTypes: [AnnouncementType.Reply],
-//   });
-//   logger.debug({messages}, `getRepliesForBlockRange messages`);
-//
-//   const replies: [number, any][] = [];
-//   // Fetch the parquet files
-//   for (const msg of messages) {
-//     const reply = await getReplyContent(msg);
-//     logger.debug({reply}, "getRepliesForBlockRange reply");
-//     if (reply) {
-//       replies.push(reply);
-//     }
-//   }
-
-// Return the replies
-//   return replies;
-// }
-
-async function getRepliesForPost(allReplies: [number, any][], contentHash: Post['contentHash']) {
-  logger.debug({ allReplies }, 'getRepliesForPost allReplies');
-
-  const repliesForPost: [number, any][] = [];
-  for (const blockNumber in allReplies) {
-    const replyObj = allReplies[blockNumber];
-    logger.debug({ replyObj }, 'getRepliesForPost replyObj');
-
-    const nestedObject: string = replyObj[1].inReplyTo;
-    logger.debug({ nestedObject }, 'getRepliesForPost nestedObject.inReplyTo');
-    logger.debug({ contentHash }, 'contentHash');
-
-    const isGood = nestedObject.endsWith(contentHash);
-    logger.debug({ isGood }, 'getRepliesForPost isGood');
-
-    if (nestedObject.endsWith(contentHash)) {
-      repliesForPost.push(replyObj[1]);
-    }
-  }
-  return repliesForPost;
+  return posts;
 }
 
 async function getPostContent(msg: AnnouncementResponse): Promise<[number, Post] | undefined> {
@@ -108,6 +47,23 @@ async function getPostContent(msg: AnnouncementResponse): Promise<[number, Post]
       responseType: 'text',
       timeout: 10000,
     });
+    const replyMessages = ContentRepository.get({ announcementTypes: [AnnouncementType.Reply] });
+    const replies: Reply[] = await Promise.all(
+      replyMessages.map(async (replyMessage): Promise<Reply> => {
+        const replyAnnouncement = replyMessage.announcement as ReplyAnnouncement;
+        const replyResp = await axios.get(translateContentUrl(replyAnnouncement.url), {
+          responseType: 'text',
+          timeout: 10000,
+        });
+
+        return {
+          fromId: replyAnnouncement.fromId,
+          contentHash: replyAnnouncement.contentHash,
+          content: replyResp.data as string,
+          timestamp: new Date().toISOString(), // TODO: use block timestamp
+        };
+      })
+    );
 
     return [
       msg.blockNumber,
@@ -116,7 +72,7 @@ async function getPostContent(msg: AnnouncementResponse): Promise<[number, Post]
         contentHash: announcement.contentHash,
         content: postResp.data as string,
         timestamp: new Date().toISOString(), // TODO: Use Block timestamp
-        replies: [],
+        replies,
       },
     ];
   } catch (err) {
@@ -126,33 +82,6 @@ async function getPostContent(msg: AnnouncementResponse): Promise<[number, Post]
     return undefined;
   }
 }
-
-// async function getReplyContent(msg: AnnouncementResponse): Promise<[number, any] | undefined> {
-//   try {
-//     const announcement = msg.announcement as ReplyAnnouncement;
-//     // TODO: Validate Hash
-//     const replyResp = await axios.get(translateContentUrl(announcement.url), {
-//       responseType: 'text',
-//       timeout: 10000,
-//     });
-//
-//     return [
-//       msg.blockNumber,
-//       {
-//         fromId: announcement.fromId,
-//         contentHash: announcement.contentHash,
-//         inReplyTo: announcement.inReplyTo,
-//         content: replyResp.data as string,
-//         timestamp: new Date().toISOString(), // TODO: Use Block timestamp
-//       },
-//     ];
-//   } catch (err) {
-//     // Skip this announcement
-//     // TODO: Try again sometime?
-//     logger.error({ err }, 'Failed to fetch reply content');
-//     return undefined;
-//   }
-// }
 
 function toRanges(prev: BlockRange[], cur: number): BlockRange[] {
   if (!prev[0]) {
@@ -172,50 +101,46 @@ function toRanges(prev: BlockRange[], cur: number): BlockRange[] {
   return prev;
 }
 
-export async function fetchAndCachePostsWithReplies(
-  newestBlockNumber: number,
-  oldestBlockNumber: number
-): Promise<void> {
+export async function fetchAndCachePosts(newestBlockNumber: number, oldestBlockNumber: number): Promise<void> {
   // Create the range
   const ranges = Array.from(
     { length: Math.abs(newestBlockNumber - oldestBlockNumber) + 1 },
     (_x, i) => oldestBlockNumber + i
   )
     // Skip those already in the cache
-    .filter((x) => !(x in cachedPosts))
+    .filter((x) => !(x in cache))
     // Create ranges
     // TODO: Handle single block requests
     .reduce(toRanges, []);
 
   for (const range of ranges) {
     // Cache the posts for each range and apply to the cache
-    const posts = await getPostsWithRepliesForBlockRange(range);
+    const posts = await getPostsForBlockRange(range);
     for (let i = range.from; i <= range.to; i++) {
       const blockPosts = posts.filter(([n]) => n === i);
       // Do not cache empty blocks
       // Post announcements (a trigger for storing content) can come after the block is initially fetched.
       // If cached while empty, the new posts will not be found and then not show in the feed.
       if (blockPosts.length > 0) {
-        cachedPosts[i] = blockPosts;
+        cache[i] = blockPosts;
       }
     }
   }
 }
 
 // Object map
-const cachedPosts: CachedPosts = {};
-// const cachedReplies: CachedReplies = {};
+const cache: CachedPosts = {};
 
 export async function getPostsInRange(newestBlockNumber: number, oldestBlockNumber: number): Promise<Post[]> {
   // Trigger the fetch and caching
-  await fetchAndCachePostsWithReplies(newestBlockNumber, oldestBlockNumber);
+  await fetchAndCachePosts(newestBlockNumber, oldestBlockNumber);
 
   const posts: Post[] = [];
   for (let i = newestBlockNumber; i >= oldestBlockNumber; i--) {
-    const blockPosts = (cachedPosts?.[i] || []).map(([_x, p]) => p);
+    const blockPosts = (cache?.[i] || []).map(([_x, p]) => p);
     posts.push(...blockPosts);
   }
-  logger.debug({ newestBlockNumber, oldestBlockNumber, posts }, 'getPostsInRange - posts');
+  logger.debug({ newestBlockNumber, oldestBlockNumber, posts }, 'getPostsInRange');
   return posts;
 }
 

--- a/backend/services/feed.ts
+++ b/backend/services/feed.ts
@@ -9,7 +9,6 @@ import {
 } from '../types/content-announcement';
 import logger from '../logger.js';
 import { translateContentUrl } from '../utils/url-transation.js';
-import { isReply } from '../types/content-announcement/type.augment.js';
 
 export type Post = T.Components.Schemas.BroadcastExtended;
 export type Reply = T.Components.Schemas.ReplyExtended;

--- a/backend/types/types.ts
+++ b/backend/types/types.ts
@@ -1,6 +1,16 @@
-import type { Components, Paths } from '../types/openapi.js';
+import type { Paths } from '../types/openapi.js';
+import {
+  type AnnouncementResponse,
+  ReplyAnnouncement,
+  ReactionAnnouncement,
+  TombstoneAnnouncement,
+  UpdateAnnouncement,
+} from './content-announcement/types.gen.js';
 
 export type AssetUploadRequest = Paths.PostAssetsHandler.RequestBody;
 
 export type PostBroadcastRequest = Paths.PostBroadcastHandler.RequestBody;
 export type PostBroadcastResponse = Paths.PostBroadcastHandler.Responses.$202;
+export type RelatedAnnouncementResponse = AnnouncementResponse & {
+  announcement: ReplyAnnouncement | ReactionAnnouncement | TombstoneAnnouncement | UpdateAnnouncement;
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -264,6 +264,7 @@ volumes:
   backend_node_cache:
   frontend_node_cache:
   redis_data:
+  content_db:
   chainstorage:
     external: false
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -207,12 +207,12 @@ services:
     ports:
       - 3001:3000
       - 3002:3001
-
     environment:
       <<: [*common-environment, *social-app-template-backend]
       IPFS_GATEWAY_URL: 'http://ipfs:8080'
     volumes:
       - ./backend:/app
+      - ${CONTENT_DB_VOLUME}:/app/db
       - backend_node_cache:/app/node_modules
     networks:
       - social-app-backend

--- a/frontend/src/content/PostList.tsx
+++ b/frontend/src/content/PostList.tsx
@@ -155,7 +155,7 @@ const PostList = ({
           )}
           {!hasMore && (
             <div className={styles.endMessageContainer}>
-              <Title level={4}>{true ? "No posts yet. May take 3-5 minutes to scan the last 48 hours of content on chain." : "That's all there is!"}</Title>
+              <Title level={4}>That's all there is!</Title>
             </div>
           )}
         </Flex>

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -95,7 +95,7 @@ EOI
     DEFAULT_IPFS_BASIC_AUTH_USER=""
     DEFAULT_IPFS_BASIC_AUTH_SECRET=""
     DEFAULT_IPFS_UA_GATEWAY_URL="http://localhost:8080"
-    DEFAULT_CONTENT_DB_VOLUME="./backend/db"
+    DEFAULT_CONTENT_DB_VOLUME="content_db"
 
 
     ask_and_save FREQUENCY_URL "Enter the Frequency Testnet RPC URL" "$DEFAULT_FREQUENCY_URL"

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -3,12 +3,12 @@
 
 # Function to ask for input with a default value and write to .env-saved
 ask_and_save() {
-    local var_name=$1
-    local prompt=$2
-    local default_value=$3
+    local var_name=${1}
+    local prompt=${2}
+    local default_value=${3}
     read -rp $'\n'"${prompt} [${default_value}]: " input
     local value=${input:-$default_value}
-    echo "$var_name=\"$value\"" >> .env-saved
+    echo "${var_name}=\"${value}\"" >> .env-saved
 }
 
 # Check for Docker and Docker Compose
@@ -19,13 +19,30 @@ fi
 
 # Load existing .env-saved file if it exists
 if [ -f .env-saved ]; then
-    cat << EOI
+    echo -e "Found saved environment from a previous run:\n"
+    cat .env-saved
+    echo
+    read -p  "Do you want to re-use the saved paramters? [y/N]: " REUSE_SAVED
+
+    if [[ ${REUSE_SAVED} =~ ^[Yy] ]]
+    then
+        cat << EOI
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Loading existing .env-saved file environment values...                                      ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
 EOI
-else
+    else
+        cat << EOI
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Removing previous saved environment...                                                      |
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+EOI
+    rm .env-saved
+    fi
+fi
+
+if [ ! -f .env-saved ]
+then
     # Setup some variables for easy port management
     STARTING_PORT=3010
     for i in {0..10}
@@ -58,30 +75,31 @@ EOI
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 EOI
-        TESTNET_ENV="testnet"
-        FREQUENCY_URL="wss://0.rpc.testnet.amplica.io"
-        FREQUENCY_HTTP_URL="https://0.rpc.testnet.amplica.io"
-        PROVIDER_ID="729"
-        PROVIDER_ACCOUNT_SEED_PHRASE="DEFAULT seed phrase needed"
-        IPFS_VOLUME="/data/ipfs"
+        DEFAULT_TESTNET_ENV="testnet"
+        DEFAULT_FREQUENCY_URL="wss://0.rpc.testnet.amplica.io"
+        DEFAULT_FREQUENCY_HTTP_URL="https://0.rpc.testnet.amplica.io"
+        DEFAULT_PROVIDER_ID="729"
+        DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE="DEFAULT seed phrase needed"
+        DEFAULT_IPFS_VOLUME="/data/ipfs"
     else
         echo -e "\nStarting on local..."
-        TESTNET_ENV="local"
-        FREQUENCY_URL="ws://frequency:9944"
-        FREQUENCY_HTTP_URL="http://localhost:9944"
-        PROVIDER_ID="1"
-        PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
-        IPFS_VOLUME="/data/ipfs"
+        DEFAULT_TESTNET_ENV="local"
+        DEFAULT_FREQUENCY_URL="ws://frequency:9944"
+        DEFAULT_FREQUENCY_HTTP_URL="http://localhost:9944"
+        DEFAULT_PROVIDER_ID="1"
+        DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
+        DEFAULT_IPFS_VOLUME="/data/ipfs"
     fi
-    IPFS_ENDPOINT="http://ipfs:5001"
-    IPFS_GATEWAY_URL='https://ipfs.io/ipfs/[CID]'
-    IPFS_BASIC_AUTH_USER=""
-    IPFS_BASIC_AUTH_SECRET=""
-    IPFS_UA_GATEWAY_URL="http://localhost:8080"
+    DEFAULT_IPFS_ENDPOINT="http://ipfs:5001"
+    DEFAULT_IPFS_GATEWAY_URL='https://ipfs.io/ipfs/[CID]'
+    DEFAULT_IPFS_BASIC_AUTH_USER=""
+    DEFAULT_IPFS_BASIC_AUTH_SECRET=""
+    DEFAULT_IPFS_UA_GATEWAY_URL="http://localhost:8080"
+    DEFAULT_CONTENT_DB_VOLUME="./backend/db"
 
 
-    ask_and_save "FREQUENCY_URL" "Enter the Frequency Testnet RPC URL" "$FREQUENCY_URL"
-    ask_and_save "FREQUENCY_HTTP_URL" "Enter the Frequency HTTP Testnet RPC URL" "$FREQUENCY_HTTP_URL"
+    ask_and_save FREQUENCY_URL "Enter the Frequency Testnet RPC URL" "$DEFAULT_FREQUENCY_URL"
+    ask_and_save FREQUENCY_HTTP_URL "Enter the Frequency HTTP Testnet RPC URL" "$DEFAULT_FREQUENCY_HTTP_URL"
 cat << EOI
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -94,8 +112,8 @@ cat << EOI
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 EOI
-    ask_and_save "PROVIDER_ID" "Enter Provider ID" "$PROVIDER_ID"
-    ask_and_save "PROVIDER_ACCOUNT_SEED_PHRASE" "Enter Provider Seed Phrase" "$PROVIDER_ACCOUNT_SEED_PHRASE"
+    ask_and_save PROVIDER_ID "Enter Provider ID" "$DEFAULT_PROVIDER_ID"
+    ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE"
     cat << EOI
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -107,13 +125,15 @@ EOI
 
     if [[ $CHANGE_IPFS_SETTINGS =~ ^[Yy]$ ]]
     then
-        ask_and_save "IPFS_VOLUME" "Enter the IPFS volume" "$IPFS_VOLUME"
-        ask_and_save "IPFS_ENDPOINT" "Enter the IPFS Endpoint" "kubo default: $IPFS_ENDPOINT"
-        ask_and_save "IPFS_GATEWAY_URL" "Enter the IPFS Gateway URL" "default public ipfs: $IPFS_GATEWAY_URL"
-        ask_and_save "IPFS_BASIC_AUTH_USER" "Enter the IPFS Basic Auth User" "$IPFS_BASIC_AUTH_USER"
-        ask_and_save "IPFS_BASIC_AUTH_SECRET" "Enter the IPFS Basic Auth Secret" "$IPFS_BASIC_AUTH_SECRET"
-        ask_and_save "IPFS_UA_GATEWAY_URL" "Enter the browser-resolveable IPFS Gateway URL" "$IPFS_UA_GATEWAY_URL"
+        ask_and_save IPFS_VOLUME "Enter the IPFS volume" "$DEFAULT_IPFS_VOLUME"
+        ask_and_save IPFS_ENDPOINT "Enter the IPFS Endpoint" "$DEFAULT_IPFS_ENDPOINT"
+        ask_and_save IPFS_GATEWAY_URL "Enter the IPFS Gateway URL" "$DEFAULT_IPFS_GATEWAY_URL"
+        ask_and_save IPFS_BASIC_AUTH_USER "Enter the IPFS Basic Auth User" "$DEFAULT_IPFS_BASIC_AUTH_USER"
+        ask_and_save IPFS_BASIC_AUTH_SECRET "Enter the IPFS Basic Auth Secret" "$DEFAULT_IPFS_BASIC_AUTH_SECRET"
+        ask_and_save IPFS_UA_GATEWAY_URL "Enter the browser-resolveable IPFS Gateway URL" "$DEFAULT_IPFS_UA_GATEWAY_URL"
     fi
+
+    ask_and_save "CONTENT_DB_VOLUME" "Enter the location of the Content DB" "${DEFAULT_CONTENT_DB_VOLUME}"
 fi
 set -a; source .env-saved; set +a
 

--- a/stop-gateway.sh
+++ b/stop-gateway.sh
@@ -11,8 +11,7 @@ echo "Shutting down any running services..."
 docker compose --profile local-node --profile backend --profile frontend down
 
 # Ask the user if they want to remove specified volumes
-echo "Do you want to remove specified volumes to remove all state and start fresh? [y/n]: "
-read REMOVE_VOLUMES
+read -p "Do you want to remove specified volumes to remove all state and start fresh? [y/N]: " REMOVE_VOLUMES
 
 if [[ $REMOVE_VOLUMES =~ ^[Yy]$ ]]
 then
@@ -28,5 +27,5 @@ then
         docker volume rm $(basename "$(pwd)" | tr '[:upper:]' '[:lower:]')_chainstorage
     fi
 else
-    echo "Not removing specified volumes..."
+    echo "Leaving Docker volumes alone."
 fi

--- a/stop-gateway.sh
+++ b/stop-gateway.sh
@@ -21,6 +21,7 @@ then
     docker volume rm ${COMPOSE_PROJECT_NAME}_redis_data
     docker volume rm ${COMPOSE_PROJECT_NAME}_ipfs_data
     docker volume rm ${COMPOSE_PROJECT_NAME}_backend_node_cache
+    docker volume rm ${COMPOSE_PROJECT_NAME}_content_db
     docker volume rm ${COMPOSE_PROJECT_NAME}_frontend_node_cache
     if [[ ! $TESTNET_ENV =~ ^[Yy]$ ]]
     then


### PR DESCRIPTION
# Purpose
The goal of this PR is to store announced chain content received from content-watcher in a persistence layer instead of just an in-memory cache, so that on subsequent restarts the SAT backend doesn't have to wait to ask content-watcher to search the chain for all the content it wants.

Also, using SQLite as the persistence layer makes it easier to store/query replies associated with primary posts.

TODO:
- [x] retrieve replies & reactions associated with posts correctly