### PR TITLE
remove trigger from postlist useeffect

### DIFF
--- a/frontend/src/content/PostList.tsx
+++ b/frontend/src/content/PostList.tsx
@@ -79,7 +79,7 @@ const PostList = ({
   useEffect(() => {
     const getOlder = refreshTrigger === priorTrigger;
     fetchData(getOlder);
-  }, [feedType, profile, refreshTrigger, priorTrigger]);
+  }, [feedType, profile, priorTrigger]);
 
   const fetchData = async (getOlder: boolean) => {
     const isAddingMore = priorFeedType === feedType;


### PR DESCRIPTION
# Purpose
The goal of this PR is to not have the feeds go blank when a new post is posted and the spinner stops

Closes #118 

## Solution
Figure out what is causing this and fix it.


### Change summary
* removed trigger from a use effect that was causing a render loop


## Steps to Verify
1. login
2. create post
3. go to any of the feeds
4. create another post
5. wait for spinner to finish and check that posts are all still there, not an empty feed when there shouldn't be.
