### PR TITLE
fix: filter replies by parent content hash when retrieving posts

### DIFF
--- a/backend/openapi-specs/graph-service-webhook.yaml
+++ b/backend/openapi-specs/graph-service-webhook.yaml
@@ -24,6 +24,21 @@ webhooks:
           description: Graph update announcement handled
         '400':
           description: Bad request
+  graph-request-status:
+    post:
+      summary: Send the status of a requested graph update
+      operationId: updateOperationStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              '$ref': '#/components/schemas/GraphOperationStatus'
+      responses:
+        '200':
+          description: Graph operation status received
+        '400':
+          description: Bad request
 components:
   schemas:
     Uint8Array:

--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -78,9 +78,6 @@ function getRelatedHash(contentAnnouncement: AnnouncementResponse): string | nul
 
 export class ContentRepository {
   private static db: any;
-  // TODO: more tightly bind the announcement types. Reactions and replies only in contentResponseMap.
-  private static contentMap = new Map<string, AnnouncementResponse>();
-  private static contentResponseMap = new Map<string, RelatedAnnouncementResponse>();
 
   static init() {
     try {


### PR DESCRIPTION
# Description
This PR adds a filter option when retrieving posts so that only replies for the current post are retrieved (previously was retrieving all repliese for all posts, for each post)

Closes #122 